### PR TITLE
Output Buffering & app stats

### DIFF
--- a/app/views/welcome/index.php
+++ b/app/views/welcome/index.php
@@ -46,7 +46,7 @@
 		<div class="clear"></div> 
 		
 
-		
+		<p>Page rendered in {elapsed_time} seconds, using {memory_usage}.</p>
 	</div>
 </body>
 </html>

--- a/core/classes/fuel/core.php
+++ b/core/classes/fuel/core.php
@@ -46,6 +46,9 @@ class Fuel_Core {
 
 		spl_autoload_register(array('Fuel', 'autoload'));
 
+		// Start up output buffering
+		ob_start();
+
 		Config::load('config');
 
 		Fuel::$bm = Config::get('benchmarking', null);
@@ -60,7 +63,7 @@ class Fuel_Core {
 		{
 			if (isset($_SERVER['SCRIPT_NAME']))
 			{
-				Config::set('base_url', dirname($_SERVER['SCRIPT_NAME']).'/');
+				Config::set('base_url', dirname($_SERVER['SCRIPT_NAME']));
 			}
 		}
 
@@ -68,6 +71,29 @@ class Fuel_Core {
 		setlocale(LC_ALL, Config::get('locale'));
 
 		Fuel::$initialized = true;
+	}
+	
+	/**
+	 * Handles all post-script execution duties, 
+	 * such as flushing buffer, displaying output
+	 * and replacing any performance statistics.
+	 */
+	public static function finish()
+	{
+		// Grab the output buffer
+		$output = ob_get_clean();
+
+		// Grab our benchmark information.
+		$benchmarks = Benchmark::app_total();
+
+		// Replace our basic performance measures.
+		// By doing it now, we are certain to have
+		// accurate reponses, even when output is cached.
+		$output = str_replace('{elapsed_time}', number_format($benchmarks[0], 4), $output);
+		$output = str_replace('{memory_usage}', round($benchmarks[1]/1048576,2) .' Mb', $output);
+
+		// Send the buffer to the browser.
+		echo $output;
 	}
 
 	/**

--- a/index.php
+++ b/index.php
@@ -79,10 +79,13 @@ else
 }
 
 // Initialize the framework
+// and start buffering the output.
 Fuel::init();
 
 $request = Request::instance();
 $request->execute();
 echo $request->output;
+
+Fuel::finish();
 
 /* End of file index.php */


### PR DESCRIPTION
I've wrapped the app execution into an output buffer, and added a finish() method to fuel/core which grabs the output buffer and replaces {memory_usage} and {elapsed_time} in the buffer before displaying, like CodeIgniter does, so that we can get a basic performance record as we develop.
