### PR TITLE
Fixed notice in the Error class

### DIFF
--- a/core/classes/fuel/error.php
+++ b/core/classes/fuel/error.php
@@ -96,7 +96,7 @@ class Fuel_Error {
 			{
 				unset($data['backtrace'][$key]);
 			}
-			if (strncmp($trace['file'], APPPATH, strlen(APPPATH)) !== 0)
+			elseif (strncmp($trace['file'], APPPATH, strlen(APPPATH)) !== 0)
 			{
 				unset($data['backtrace'][$key]);
 			}


### PR DESCRIPTION
Error class throws a notice error when $trace['file'] doesn't exist

(p.s. ignore the previous pull request, forgot to switch branches)
