### PR TITLE
Small modifications to pagination class

### DIFF
--- a/fuel/app/classes/controller/test.php
+++ b/fuel/app/classes/controller/test.php
@@ -36,7 +36,7 @@ class Controller_Test extends Controller\Base {
 		$config = array(
 			'total_items' => $count,
 			'per_page' => 5,
-			'pagination_url' => 'welcome/pagination',
+			'pagination_url' => 'test/pagination',
 			'uri_segment' => 3,
 			'num_links' => 5, // this is not required and is the number of links on each side of the current page
 		);

--- a/fuel/core/classes/pagination.php
+++ b/fuel/core/classes/pagination.php
@@ -153,7 +153,8 @@ class Pagination {
 			}
 			else
 			{
-				$pagination .= URL::anchor(rtrim(static::$pagination_url, '/').'/'.$i, $i);
+				$url = ($i == 1) ? '' : '/'.$i;
+				$pagination .= URL::anchor(rtrim(static::$pagination_url, '/') . $url, $i);
 			}
 		}
 
@@ -212,7 +213,8 @@ class Pagination {
 		else
 		{
 			$previous_page = static::$current_page - 1;
-			return URL::anchor(rtrim(static::$pagination_url, '/').'/'.$previous_page, $value);
+			$previous_page = ($previous_page == 1) ? '' : '/' . $previous_page;
+			return URL::anchor(rtrim(static::$pagination_url, '/') . $previous_page, $value);
 		}
 	}
 }


### PR DESCRIPTION
Included small modification to pagination library.
Originaly it would generate links like:
/pagination
/pagination/1 (this comes out when we go to previous page)
/pagination/2

now we always have:
/pagination
/pagination/2
/pagination/3

Comments appreciated.

And fixed small type in test controller.
