### PR TITLE
Develop

### DIFF
--- a/fuel/core/classes/database/query.php
+++ b/fuel/core/classes/database/query.php
@@ -209,7 +209,7 @@ class Database_Query {
 		}
 */
 
-		switch(substr($sql, 0, 6))
+		switch(strtoupper(substr($sql, 0, 6)))
 		{
 			case 'SELECT':
 				$this->_type = Database::SELECT;


### PR DESCRIPTION
When having a lowercase SELECT in the SQL-statement (like: "Select" or "select"  the query would not return the same result as with "SELECT"
