### PR TITLE
Fix model join

### DIFF
--- a/fuel/packages/activerecord/classes/model.php
+++ b/fuel/packages/activerecord/classes/model.php
@@ -915,6 +915,14 @@ class Model {
 				{
 					foreach ($cols as $key => $col)
 					{
+                                                // Compare the values currently in $select to see if we need to remove them
+                                                if($this->table_name == $table){
+                                                        $foundKey=array_search($col,$select);
+                                                        if($foundKey !== false){
+                                                                unset($select[$foundKey]);
+                                                        }
+                                                }
+
 						// Add this to the select array
 						array_push($select, array($table.'.'.$col, "t{$table_key}_r$key"));
 


### PR DESCRIPTION
## Example code:

<?php
class Model_News extends ActiveRecord\Model
{
    public function getNewsByTag($tag)
    {
        $results = $this->find('all',array(
            'select'        => array('title','story','date','ID'),
            'limit'         => 10,
            'order'         => array('date','desc'),
            'include'       => array('news_tags'),
            'where'         => array(
                array('tag','in',array($tag))
            )
        ));
        return $results;
    }
}
?>
## Expected Result:

SELECT `news`.`title` AS `t0_r0`, `news`.`date` AS `t0_r1`, `news`.`author` AS `t0_r2`, `news`.`story` AS `t0_r3`, `news`.`ID` AS `t0_r4`, `news`.`views` AS `t0_r5`, `news`.`del_tags` AS `t0_r6`, `news`.`post_image` AS `t0_r7`, `news`.`type` AS `t0_r8`, `news_tags`.`news_id` AS `t1_r0`, `news_tags`.`tag` AS `t1_r1`, 
`news_tags`.`ID` AS `t1_r2` FROM `news` LEFT OUTER JOIN `news_tags` ON (`news_tags`.`news_id` = `news`.`id`) WHERE `tag` IN ('base') ORDER BY `date` DESC LIMIT 10
## Actual Result:

SELECT `title`, `story`, `date`, `ID`, `news`.`title` AS `t0_r0`, `news`.`date` AS `t0_r1`, `news`.`author` AS `t0_r2`, `news`.`story` AS `t0_r3`, `news`.`ID` AS `t0_r4`, `news`.`views` AS `t0_r5`, `news`.`del_tags` AS `t0_r6`, `news`.`post_image` AS `t0_r7`, `news`.`type` AS `t0_r8`, `news_tags`.`news_id` AS `t1_r0`, `news_tags`.`tag` AS `t1_r1`, `news_tags`.`ID` AS `t1_r2` FROM `news`  LEFT OUTER JOIN `news_tags` ON (`news_tags`.`news_id` = `news`.`id`) WHERE `tag` IN ('base') ORDER BY `date` DESC LIMIT 10

Columns already in "select" on find() are still in the query and could cause SQL errors (like "ambiguous column ID" in this case). Patch looks at the current $select and $table_name to find the ones that should be unset.
