### PR TITLE
Changed INTERNAL_ENC to UTF-8 instead of ISO-8859-1

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -22,7 +22,7 @@ define('DEBUG', false);
  *
  * @todo Re-evaluate how to handle this.
  */
-define('INTERNAL_ENC', 'ISO-8859-1');
+define('INTERNAL_ENC', 'UTF-8');
 
 /**
  * Website docroot


### PR DESCRIPTION
The UTF-8 allows for Swedish (among many other) characters to be used and parsed correctly.
