### PR TITLE
Fix Simpleauth get_user_id() bug.

### DIFF
--- a/fuel/packages/auth/classes/auth/login/simpleauth.php
+++ b/fuel/packages/auth/classes/auth/login/simpleauth.php
@@ -322,7 +322,7 @@ class Auth_Login_SimpleAuth extends \Auth_Login_Driver {
 			return false;
 		}
 
-		return array($this->id, (int) $this->user->id);
+		return array($this->id, (int) $this->user->get('id'));
 	}
 
 	/**


### PR DESCRIPTION
At the minute, it returns $this->user->id which gives ErrorException [ Notice ]: Undefined property: Fuel\Core\Database_MySQL_Result::$id. It should use $this->user->get('id'), which returns the id from the array of user details
