### PR TITLE
Pagination changes

### DIFF
--- a/fuel/core/classes/pagination.php
+++ b/fuel/core/classes/pagination.php
@@ -80,9 +80,9 @@ class Pagination {
 	 */
 	protected static $method = 0; // static::CLASSIC
 	
-	const CLASSIC = 0;
-	const SEGMENT_TAG = 1;
-	const GET_TAG = 2;
+	const CLASSIC = 'classic';
+	const SEGMENT_TAG = 'segment_tag';
+	const GET_TAG = 'get_tag';
 
 
 
@@ -258,7 +258,7 @@ class Pagination {
 	 */
 	public static function pagination_url($page_nr)
 	{
-		switch (static::$method) 
+		switch (strtolower(static::$method)) 
 		{
 			case static::CLASSIC:
 			
@@ -322,7 +322,7 @@ class Pagination {
 	 */
 	public static function current_page()
 	{
-		switch (static::$method) 
+		switch (strtolower(static::$method)) 
 		{
 			case static::CLASSIC:
 		  	case static::SEGMENT_TAG:


### PR DESCRIPTION
Fully backwards compatible.

Example usage:

```
`         
    //fully backwards compatible, no need to change anything in the way you use it:

    //except for the {p} lol, ill fix that later to make it 'more' fully backwards compatible :P 
    /*
    $config = array(
        'pagination_url' => \Uri::create('welcome/pagination/{p}'),
        'total_items' => 17,
        'per_page' => 5,
        'uri_segment' => 3,
    );
    */

    //new adition:

    //examples of posibble urls to use:
    $u1 = \Uri::create('welcome/pagination?{p}');
    $u2 = \Uri::create('welcome/pagination?aaa=bbb&{p}');
    $u3 = \Uri::create('welcome/pagination?{p}&aaa=bbb');
    $u4 = \Uri::create('welcome/pagination?aaa=bbb&{p}&ccc=ddd');

    //get:
    $config = array(
        'pagination_url' => $u1,
        'total_items' => 17,
        'per_page' => 5,
        'method' => \Pagination::GET,
        //optional:
        //'get_variable'  => 'pagina',
        //'replacement_tag' => '{ppp}',
    );

    //Note: for the link for page 1, the page var is taken out
    // similar to how `.../1` is not shown it in classic segment style

    // Config::set('pagination', $config); // you can use this too!
    Pagination::set_config($config);

    echo Pagination::create_links();`
```
