### PR TITLE
Develop: Assets: Automatically add missing file extension to JavaScript and Stylesheet files

### DIFF
--- a/fuel/core/classes/asset.php
+++ b/fuel/core/classes/asset.php
@@ -320,6 +320,19 @@ class Asset {
 		{
 			$assets = array($assets);
 		}
+		//Automatically add missing file extension to JavaScript and Stylesheet files
+		switch ($type) {
+			case 'js':
+			case 'css':
+				foreach ($assets as $key => $asset)
+				{
+					if (preg_match('/\.'.$type.'$/', $asset) === 0)
+					{
+						$assets[$key] = $asset.'.'.$type;
+					}
+				}
+			break;
+		}
 
 		foreach ($assets as $key => $asset)
 		{


### PR DESCRIPTION
As I've posted in the forum I think the Asset class should add a file extension to JavaScript and Stylesheet files if the extension was omitted when calling Asset::css('file') or Asset::js('file'). This behaviour is used at least by Symfony.
