### PR TITLE
Added Controller_Template_Ajax

### DIFF
--- a/fuel/core/classes/controller/template/ajax.php
+++ b/fuel/core/classes/controller/template/ajax.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.0
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2010 - 2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+namespace Fuel\Core;
+
+/**
+ * AJAX Template Controller class
+ *
+ * If a request is AJAX, the template view is not rendered but only the content is
+ *
+ * @package		Fuel
+ * @category	Core
+ * @author		Tom Arnfeld (@tarnfeld)
+ */
+abstract class Controller_Template_Ajax extends \Controller_Template {
+
+	// After contorller method has run output the template if the request is not ajax
+	public function after()
+	{
+		
+		parent::after();
+		
+		if ($this->auto_render === true)
+		{
+			if(Input::is_ajax()) {
+				$this->output = $this->template->content;
+			} else {
+				$this->output = $this->template;
+			}
+		}
+	}
+
+}
+/* End of file template.php */

--- a/fuel/packages/activerecord/classes/model.php
+++ b/fuel/packages/activerecord/classes/model.php
@@ -982,10 +982,17 @@ class Model {
 			$query->offset($options['offset']);
 		}
 
-		// Get the order
-		if (array_key_exists('order', $options) && is_array($options['order']))
+		// Get the order using new array('field' => 'asc', 'anotherfield' => 'desc') but with support for array('field', 'asc')
+		if (array_key_exists('order', $options))
 		{
-			$query->order_by($options['order'][0], $options['order'][1]);
+			$is_associative = array_keys($options['order']) !== range(0, count($options['order']) - 1);
+			if($is_associative) {
+				foreach($options['order'] as $field => $order) {
+					$query->order_by($field, $order);
+				}
+			} else {
+				$query->order_by($options['order'][0], $options['order'][1]);
+			}
 		}
 
 		// Get the group


### PR DESCRIPTION
I thought this would be useful since I like being able to easily implement ajax for a controller method. This way I could use a normal controller method that works with a standard form post/link but using AJAX pull the content that I really care about into the current "template" you're on.

All you need to add then to get ajax working for an action is pop in some jquery like so `$('.content').html(ajax_data);` and it works just like normal :)
