### PR TITLE
Oil Generate Migration

### DIFF
--- a/fuel/packages/oil/bootstrap.php
+++ b/fuel/packages/oil/bootstrap.php
@@ -14,13 +14,14 @@
 
 
 Fuel\Core\Autoloader::add_classes(array(
-	'Oil\\Cli'			=> __DIR__.'/classes/cli.php',
-	'Oil\\Console'		=> __DIR__.'/classes/console.php',
-	'Oil\\Exception'	=> __DIR__.'/classes/exception.php',
-	'Oil\\Generate'		=> __DIR__.'/classes/generate.php',
-	'Oil\\Package'		=> __DIR__.'/classes/package.php',
-	'Oil\\Refine'		=> __DIR__.'/classes/refine.php',
-	'Oil\\Scaffold'		=> __DIR__.'/classes/scaffold.php',
+	'Oil\\Cli'							=> __DIR__.'/classes/cli.php',
+	'Oil\\Console'						=> __DIR__.'/classes/console.php',
+	'Oil\\Exception'					=> __DIR__.'/classes/exception.php',
+	'Oil\\Generate'						=> __DIR__.'/classes/generate.php',
+	'Oil\\Generate_Migration_Actions'	=> __DIR__.'/classes/generate/migration/actions.php',
+	'Oil\\Package'						=> __DIR__.'/classes/package.php',
+	'Oil\\Refine'						=> __DIR__.'/classes/refine.php',
+	'Oil\\Scaffold'						=> __DIR__.'/classes/scaffold.php',
 ));
 
 /* End of file bootstrap.php */

--- a/fuel/packages/oil/bootstrap.php
+++ b/fuel/packages/oil/bootstrap.php
@@ -14,14 +14,14 @@
 
 
 Fuel\Core\Autoloader::add_classes(array(
-	'Oil\\Cli'							=> __DIR__.'/classes/cli.php',
-	'Oil\\Console'						=> __DIR__.'/classes/console.php',
-	'Oil\\Exception'					=> __DIR__.'/classes/exception.php',
+	'Oil\\Cli'						   	=> __DIR__.'/classes/cli.php',
+	'Oil\\Console'					   	=> __DIR__.'/classes/console.php',
+	'Oil\\Exception'				   	=> __DIR__.'/classes/exception.php',
 	'Oil\\Generate'						=> __DIR__.'/classes/generate.php',
 	'Oil\\Generate_Migration_Actions'	=> __DIR__.'/classes/generate/migration/actions.php',
-	'Oil\\Package'						=> __DIR__.'/classes/package.php',
-	'Oil\\Refine'						=> __DIR__.'/classes/refine.php',
-	'Oil\\Scaffold'						=> __DIR__.'/classes/scaffold.php',
+	'Oil\\Package'					 	=> __DIR__.'/classes/package.php',
+	'Oil\\Refine'					 	=> __DIR__.'/classes/refine.php',
+	'Oil\\Scaffold'					 	=> __DIR__.'/classes/scaffold.php',
 ));
 
 /* End of file bootstrap.php */

--- a/fuel/packages/oil/classes/generate.php
+++ b/fuel/packages/oil/classes/generate.php
@@ -176,7 +176,7 @@ VIEW;
 			{
 				$method = $action.'_action';
 				
-				$migration = call_user_func(__NAMESPACE__ . "\Generate_Migration_Actions::{$method}", $migration_name);
+				$migration = call_user_func(__NAMESPACE__ . "\Generate_Migration_Actions::{$method}", $migration_name, $args);
 				break;
 			}
 		}

--- a/fuel/packages/oil/classes/generate.php
+++ b/fuel/packages/oil/classes/generate.php
@@ -159,57 +159,30 @@ VIEW;
 	public function migration($args)
 	{
 		$migration_name = strtolower(array_shift($args));
-
-		// Starts with create, so lets create a table
-		if (strpos($migration_name, 'create_') === 0)
+		
+		$actions = array(
+			'create_'		=> 'create_table',
+			'add_'			=> 'add_fields',
+			'remove_'		=> 'remove_field',
+			'rename_table_'	=> 'rename_table',
+			'drop_'			=> 'drop_table'
+		);
+		
+		$migration = array('', '');
+		foreach($actions as $prefix => $action)
 		{
-			$mode = 'create_table';
-			$table = str_replace('create_', '', $migration_name);
-		}
-
-		// add_field_to_table
-		else if (strpos($migration_name, 'add_') === 0)
-		{
-			$mode = 'add_fields';
-
-			preg_match('/add_[a-z0-9_]+_to_([a-z0-9_]+)/i', $migration_name, $matches);
-
-			$table = $matches[1];
-		}
-
-		// remove_field_from_table
-		else if (strpos($migration_name, 'remove_') === 0)
-		{
-			$mode = 'remove_field';
-
-			preg_match('/remove_([a-z0-9_])+_from_([a-z0-9_]+)/i', $migration_name, $matches);
-
-			$remove_field = $matches[1];
-			$table = $matches[2];
+			// If the migration name starts with one of the actions, call it.
+			if(substr($migration_name, 0, strlen($prefix)) == $prefix)
+			{
+				$method = $action.'_action';
+				
+				$migration = call_user_func(__NAMESPACE__ . "\Generate_Migration_Actions::{$method}", $migration_name);
+				break;
+			}
 		}
 		
-		// rename_table_to_newtable
-		else if (strpos($migration_name, 'rename_table_') === 0)
-		{
-			$mode = 'rename_table';
-
-			preg_match('/rename_table_([a-z0-9_]+)+_to_([a-z0-9_]+)/i', $migration_name, $matches);
-			
-			$table = $matches[1];
-			$args[] = $matches[2];
-		}
-
-		// drop_table
-		else if (strpos($migration_name, 'drop_') === 0)
-		{
-			$mode = 'drop_table';
-			$table = str_replace('drop_', '', $migration_name);
-		}
-		unset($matches);
-
-		// Now that we know that, lets build the migration
-
-		if ($filepath = static::_build_migration($migration_name, $mode, $table, $args))
+		// Build the migration
+		if ($filepath = static::_build_migration($migration_name, $migration[0], $migration[1]))
 		{
 			\Cli::write('Created migration: ' . \Fuel::clean_path($filepath));
 		}
@@ -275,94 +248,9 @@ HELP;
 	}
 
 
-	private function _build_migration($migration_name, $mode, $table, $args)
+	private function _build_migration($migration_name, $up, $down)
 	{
 		$migration_name = ucfirst(strtolower($migration_name));
-
-		if ($mode == 'create_table' or $mode == 'add_fields')
-		{
-			// Store an aray of what fields are being added
-			$fields = array();
-			
-			$field_str = '';
-
-			foreach ($args as $arg)
-			{
-				// Parse the argument for each field in a pattern of name:type[constraint]
-				preg_match('/([a-z0-9_]+):([a-z0-9_]+)(\[([0-9]+)\])?/i', $arg, $matches);
-
-				$name = $fields[] = $matches[1];
-				$type = $matches[2];
-				$constraint = isset($matches[4]) ? $matches[4] : null;
-
-				if ($type === 'string')
-				{
-					$type = 'varchar';
-				}
-				
-				else if ($type === 'integer')
-				{
-					$type = 'int';
-				}
-
-				if (in_array($type, array('text', 'blob', 'datetime')))
-				{
-					$field_str .= "\t\t\t'$name' => array('type' => '$type'),".PHP_EOL;
-				}
-
-				else
-				{
-					if ($constraint === null)
-					{
-						$constraint = self::$_default_constraints[$type];
-					}
-
-					$field_str .= "\t\t\t'$name' => array('type' => '$type', 'constraint' => $constraint),".PHP_EOL;
-				}
-			}
-
-		}
-
-		// Make the up and down based on mode
-		switch ($mode)
-		{
-			case 'create_table':
-
-				// Shove an id field at the start
-				$field_str = "\t\t\t'id' => array('type' => 'int', 'auto_increment' => true),".PHP_EOL . $field_str;
-
-				$up = <<<UP
-		\DBUtil::create_table('{$table}', array(
-$field_str
-		), array('id'));
-UP;
-
-				$down = <<<DOWN
-		\DBUtil::drop_table('{$table}');
-DOWN;
-			break;
-
-			case 'drop_table':
-				$up = <<<UP
-		\DBUtil::drop_table('{$table}');
-UP;
-				$down = '';
-			break;
-			
-			case 'rename_table':
-				$up = <<<UP
-		\DBUtil::rename_table('{$table}', '{$args[0]}');
-UP;
-				$down = <<<DOWN
-		\DBUtil::rename_table('{$args[0]}', '{$table}');
-DOWN;
-			break;
-
-			default:
-				$up = '';
-				$down = '';
-		}
-
 
 		$migration = <<<MIGRATION
 <?php

--- a/fuel/packages/oil/classes/generate/migration/actions.php
+++ b/fuel/packages/oil/classes/generate/migration/actions.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.0
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2010 - 2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+namespace Oil;
+
+/**
+ * Oil\Generate_Migration_Actions
+ * Handles actions for generating migrations in Oil
+ *
+ * @package		Fuel
+ * @subpackage	Oil
+ * @category	Core
+ * @author		Tom Arnfeld
+ */
+class Generate_Migration_Actions
+{
+	
+	/**
+	 * Each migration action should return an array with two items, 0 being up and 1 being down.
+	 */
+	
+	// Create table
+	public static function create_table_action($migration_name)
+	{
+		$table = str_replace('create_', '', $migration_name);
+		
+		return array('', '');
+	}
+	
+	// Add Fields to table
+	public static function add_fields_action($migration_name)
+	{
+		preg_match('/add_[a-z0-9_]+_to_([a-z0-9_]+)/i', $migration_name, $matches);
+		$table = $matches[1];
+		
+		return array('', '');
+	}
+	
+	// Remove fields from table
+	public static function remove_field_action($migration_name)
+	{
+		preg_match('/remove_([a-z0-9_])+_from_([a-z0-9_]+)/i', $migration_name, $matches);
+
+		$remove_field = $matches[1];
+		$table = $matches[2];
+		
+		return array('', '');
+	}
+	
+	// Rename a table
+	public static function rename_table_action($migration_name)
+	{
+		preg_match('/rename_table_([a-z0-9_]+)+_to_([a-z0-9_]+)/i', $migration_name, $matches);
+		
+		$table = $matches[1];
+		$args[] = $matches[2];
+		
+		return array('', '');
+	}
+	
+	// Drop a table
+	public static function drop_table_action($migration_name)
+	{
+		$table = str_replace('drop_', '', $migration_name);
+		
+		return array('', '');
+	}
+	
+}

--- a/fuel/packages/oil/classes/generate/migration/actions.php
+++ b/fuel/packages/oil/classes/generate/migration/actions.php
@@ -31,15 +31,63 @@ class Generate_Migration_Actions
 	 */
 	
 	// Create table
-	public static function create_table_action($migration_name)
+	public static function create_table_action($migration_name, $args)
 	{
 		$table = str_replace('create_', '', $migration_name);
 		
-		return array('', '');
+		$fields = array();
+
+		$field_str = '';
+
+		foreach ($args as $arg)
+		{
+			// Parse the argument for each field in a pattern of name:type[constraint]
+			preg_match('/([a-z0-9_]+):([a-z0-9_]+)(\[([0-9]+)\])?/i', $arg, $matches);
+
+			$name = $fields[] = $matches[1];
+			$type = $matches[2];
+			$constraint = isset($matches[4]) ? $matches[4] : null;
+
+			if ($type === 'string')
+			{
+				$type = 'varchar';
+			}
+			else if ($type === 'integer')
+			{
+				$type = 'int';
+			}
+			if (in_array($type, array('text', 'blob', 'datetime')))
+			{
+				$field_str .= "\t\t\t'$name' => array('type' => '$type'),".PHP_EOL;
+			}
+			else
+			{
+				if ($constraint === null)
+				{
+					$constraint = self::$_default_constraints[$type];
+				}
+
+				$field_str .= "\t\t\t'$name' => array('type' => '$type', 'constraint' => $constraint),".PHP_EOL;
+			}
+		}
+		
+		$field_str = "\t\t\t'id' => array('type' => 'int', 'auto_increment' => true),".PHP_EOL . $field_str;
+
+		$up = <<<UP
+		\DBUtil::create_table('{$table}', array(
+$field_str
+		), array('id'));
+UP;
+
+		$down = <<<DOWN
+		\DBUtil::drop_table('{$table}');
+DOWN;
+		
+		return array($up, $down);
 	}
 	
 	// Add Fields to table
-	public static function add_fields_action($migration_name)
+	public static function add_fields_action($migration_name, $args)
 	{
 		preg_match('/add_[a-z0-9_]+_to_([a-z0-9_]+)/i', $migration_name, $matches);
 		$table = $matches[1];
@@ -48,7 +96,7 @@ class Generate_Migration_Actions
 	}
 	
 	// Remove fields from table
-	public static function remove_field_action($migration_name)
+	public static function remove_field_action($migration_name, $args)
 	{
 		preg_match('/remove_([a-z0-9_])+_from_([a-z0-9_]+)/i', $migration_name, $matches);
 
@@ -59,22 +107,34 @@ class Generate_Migration_Actions
 	}
 	
 	// Rename a table
-	public static function rename_table_action($migration_name)
+	public static function rename_table_action($migration_name, $args)
 	{
 		preg_match('/rename_table_([a-z0-9_]+)+_to_([a-z0-9_]+)/i', $migration_name, $matches);
 		
 		$table = $matches[1];
 		$args[] = $matches[2];
 		
-		return array('', '');
+		$up = <<<UP
+		\DBUtil::rename_table('{$table}', '{$args[0]}');
+UP;
+		$down = <<<DOWN
+		\DBUtil::rename_table('{$args[0]}', '{$table}');
+DOWN;
+		
+		return array($up, $down);
 	}
 	
 	// Drop a table
-	public static function drop_table_action($migration_name)
+	public static function drop_table_action($migration_name, $args)
 	{
 		$table = str_replace('drop_', '', $migration_name);
 		
-		return array('', '');
+		$up = <<<UP
+		\DBUtil::drop_table('{$table}');
+UP;
+		$down = '';
+		
+		return array($up, $down);
 	}
 	
 }

--- a/fuel/packages/oil/classes/generate/migration/actions.php
+++ b/fuel/packages/oil/classes/generate/migration/actions.php
@@ -27,114 +27,78 @@ class Generate_Migration_Actions
 {
 	
 	/**
-	 * Each migration action should return an array with two items, 0 being up and 1 being down.
+	 * Each migration action should return an array with two items, 0 being the up and 1 the being down.
 	 */
 	
-	// Create table
-	public static function create_table_action($migration_name, $args)
+	// create_{tablename}
+	public static function create($subjects, $fields)
 	{
-		$table = str_replace('create_', '', $migration_name);
-		
-		$fields = array();
-
 		$field_str = '';
-
-		foreach ($args as $arg)
+		
+		foreach($fields as $field)
 		{
-			// Parse the argument for each field in a pattern of name:type[constraint]
-			preg_match('/([a-z0-9_]+):([a-z0-9_]+)(\[([0-9]+)\])?/i', $arg, $matches);
-
-			$name = $fields[] = $matches[1];
-			$type = $matches[2];
-			$constraint = isset($matches[4]) ? $matches[4] : null;
-
-			if ($type === 'string')
+			$name = array_shift($field);
+			
+			$field_opts = array();
+			foreach($field as $option => $val)
 			{
-				$type = 'varchar';
+				$field_opts[] = "'$option' => '$val'";
 			}
-			else if ($type === 'integer')
-			{
-				$type = 'int';
-			}
-			if (in_array($type, array('text', 'blob', 'datetime')))
-			{
-				$field_str .= "\t\t\t'$name' => array('type' => '$type'),".PHP_EOL;
-			}
-			else
-			{
-				if ($constraint === null)
-				{
-					$constraint = self::$_default_constraints[$type];
-				}
-
-				$field_str .= "\t\t\t'$name' => array('type' => '$type', 'constraint' => $constraint),".PHP_EOL;
-			}
+			$field_opts = implode(', ', $field_opts);
+			
+			$field_str .= "\t\t\t'$name' => array({$field_opts}),".PHP_EOL;			
 		}
 		
+		// ID Field
 		$field_str = "\t\t\t'id' => array('type' => 'int', 'auto_increment' => true),".PHP_EOL . $field_str;
 
 		$up = <<<UP
-		\DBUtil::create_table('{$table}', array(
+		\DBUtil::create_table('{$subjects[1]}', array(
 $field_str
 		), array('id'));
 UP;
 
 		$down = <<<DOWN
-		\DBUtil::drop_table('{$table}');
+		\DBUtil::drop_table('{$subjects[1]}');
 DOWN;
 		
 		return array($up, $down);
 	}
 	
-	// Add Fields to table
-	public static function add_fields_action($migration_name, $args)
+	// add_{thing}_to_{tablename}
+	public static function add($subjects, $fields)
 	{
-		preg_match('/add_[a-z0-9_]+_to_([a-z0-9_]+)/i', $migration_name, $matches);
-		$table = $matches[1];
-		
-		return array('', '');
+		return array("\t\t\t// Not yet implemented this migration action", '\t\t\t// Not yet implemented this migration action');
 	}
 	
-	// Remove fields from table
-	public static function remove_field_action($migration_name, $args)
-	{
-		preg_match('/remove_([a-z0-9_])+_from_([a-z0-9_]+)/i', $migration_name, $matches);
-
-		$remove_field = $matches[1];
-		$table = $matches[2];
-		
-		return array('', '');
+	// remove_{tablename}
+	public static function remove($subjects, $fields)
+	{	
+		return array('\t\t\t// Not yet implemented this migration action', '\t\t\t// Not yet implemented this migration action');
 	}
 	
-	// Rename a table
-	public static function rename_table_action($migration_name, $args)
+	// rename_table_{tablename}_to_{newtablename}
+	public static function rename_table($subjects, $fields)
 	{
-		preg_match('/rename_table_([a-z0-9_]+)+_to_([a-z0-9_]+)/i', $migration_name, $matches);
-		
-		$table = $matches[1];
-		$args[] = $matches[2];
 		
 		$up = <<<UP
-		\DBUtil::rename_table('{$table}', '{$args[0]}');
+		\DBUtil::rename_table('{$subjects[0]}', '{$subjects[1]}');
 UP;
 		$down = <<<DOWN
-		\DBUtil::rename_table('{$args[0]}', '{$table}');
+		\DBUtil::rename_table('{$subjects[1]}', '{$subjects[0]}');
 DOWN;
 		
 		return array($up, $down);
 	}
 	
-	// Drop a table
-	public static function drop_table_action($migration_name, $args)
-	{
-		$table = str_replace('drop_', '', $migration_name);
-		
+	// drop_{tablename}
+	public static function drop($subjects, $fields)
+	{	
 		$up = <<<UP
-		\DBUtil::drop_table('{$table}');
+		\DBUtil::drop_table('{$subjects[1]}');
 UP;
-		$down = '';
 		
-		return array($up, $down);
+		return array($up, '');
 	}
 	
 }


### PR DESCRIPTION
In this pull request I rebuilt the way migration generation works in Oil. It's now based on actions, to add a new prefixed action like say `remove_field` all you have to do is add that static method to the actions class and your good to go.

Sorting out the fields and their properties is now taken out of each action, and is sorted out into a nice array to be passed to the action. This means it's now easy to implement checking for flags like `:unique` or `:notnull` which might be useful for certain fields...

The magic parts of a migration name such as `create_**tablename**` are now passed to an action in a `$subjects` array. If you were writing an action like `create_tablename` the `tablename` would be passed at index [1] of the array. But if you were adding an action like `rename_field_**fieldname**_to_**newfield**` the first index of the subjects array would be `fieldname` and the second `newfield`.

Hope this all looks ok to you! I did some testing and it seems to work fine running the full suite of implemented actions.
- `php oil g migration create_users name:string[50] email:string[100] bio:text joined:datetime`
- `php oil g migration rename_table_users_to_people`
- `php oil g migration drop_people`
