### PR TITLE
Activerecord count

### DIFF
--- a/fuel/packages/activerecord/classes/model.php
+++ b/fuel/packages/activerecord/classes/model.php
@@ -21,7 +21,7 @@ use \Inflector;
 
 class Model {
 
-	private const IS_COUNT = 1;
+	const IS_COUNT = 1;
 
 	/**
 	 * Queries the table for the given primary key value ($id).  $id can also

--- a/fuel/packages/activerecord/classes/model.php
+++ b/fuel/packages/activerecord/classes/model.php
@@ -21,7 +21,7 @@ use \Inflector;
 
 class Model {
 
-	const IS_COUNT = 1;
+	const IS_COUNT = 'IS_COUNT_random_hghj8uyt567uygfvb876trf';
 
 	/**
 	 * Queries the table for the given primary key value ($id).  $id can also

--- a/fuel/packages/activerecord/classes/model.php
+++ b/fuel/packages/activerecord/classes/model.php
@@ -1122,11 +1122,8 @@ class Model {
 		}
 
 		// Start building the query
-		//DB::select(DB::expr('COUNT(*) AS mycount'))
 		$query = DB::select(DB::expr('COUNT(*) AS mycount'));
-		//$query = call_user_func_array('DB::select', $select);
-		//$query = call_user_func_array('DB::select', arraycall_user_func_array('DB::expr', 'COUNT(*) AS mycount'));
-
+	
 		$query->from($this->table_name);
 
 		foreach ($joins as $join)


### PR DESCRIPTION
added count function, parameters are exactly as for find(), except it returns row count 

FIY I only copy-pasted the code in `find_query()` with ONLY a couple of lines modified: 

you might consider this a hack.

`$query = call_user_func_array('DB::select', $select);`

to

`$query = DB::select(DB::expr('COUNT(*) AS mycount'));`

and:

```
$result = $query->execute();
return array('result' => $result, 'column_lookup' => $column_lookup);
```

to

`return $query->execute()->get('mycount');`
