### PR TITLE
Array Class Fix

### DIFF
--- a/fuel/core/classes/arr.php
+++ b/fuel/core/classes/arr.php
@@ -67,6 +67,10 @@ class Arr {
 		$key = explode('.', $key);
 		if(count($key) > 1)
 		{
+			if ( ! is_array($array) || ! array_key_exists($key[0], $array))
+			{
+				return $default;
+			}
 			$array = $array[$key[0]];
 			unset($key[0]);
 			$key = implode('.', $key);


### PR DESCRIPTION
fixed an issue where a middle element does not exist when using the dot notation. for instance when using the string user.name.full, if name did not exist it would not have caught it and thrown an error
