### PR TITLE
using activerecord package inside init of autoloading class set in config autoload

### DIFF
--- a/fuel/packages/activerecord/classes/association.php
+++ b/fuel/packages/activerecord/classes/association.php
@@ -46,7 +46,15 @@ class Association {
 			$this->foreign_key = \Inflector::foreign_key($this->source_class);
 		}
 
-		$namespace = ucfirst(\Request::active()->module).'\\';
+		if (\Request::active())
+		{
+			$namespace = ucfirst(\Request::active()->module).'\\';
+		}
+		else
+		{
+			$namespace = '\\';
+		}
+
 		if (class_exists($dest = $namespace.'Model_'.$this->dest_class))
 		{
 			$this->dest_class = $dest;


### PR DESCRIPTION
If you use activerecord package insite an _init() function that is autoloaded set in config autoload, the `\Request::active()` is not loaded yet thus you will get an exeption getting the module `\Request::active()->module`.
