### PR TITLE
fixed wrong extend in view exception class

### DIFF
--- a/fuel/core/classes/view/exception.php
+++ b/fuel/core/classes/view/exception.php
@@ -14,4 +14,4 @@
 
 namespace Fuel\Core;
 
-class View_Exception extends Fuel_Exception{ }
+class View_Exception extends Exception {}


### PR DESCRIPTION
I know the exception is changed in develop to `extends Fuel_Exception` but as long it is not merged to master, this is a fix to the bug in master.
