### PR TITLE
Security + Validation class bugfix

### DIFF
--- a/fuel/core/classes/security.php
+++ b/fuel/core/classes/security.php
@@ -85,7 +85,17 @@ class Security {
 				{
 					foreach($var as $key => $value)
 					{
-						$var[$key] = call_user_func($filter, $value);
+						if (is_array($value))
+						{	
+							foreach($value as $k => $el)
+							{
+								$var[$key][$k] = call_user_func($filter, $el);
+							}
+						}
+						else
+						{
+							$var[$key] = call_user_func($filter, $value);
+						}
 					}
 				}
 				else

--- a/fuel/core/classes/validation.php
+++ b/fuel/core/classes/validation.php
@@ -229,7 +229,17 @@ class Validation {
 				{
 					$callback	= $rule[0];
 					$params		= $rule[1];
-					$this->_run_rule($callback, $value, $params, $field);
+					if (is_array($value))
+					{
+						foreach ($value as $key => $element)
+						{
+							$this->_run_rule($callback, $element, $params, $field);
+						}
+					}
+					else
+					{
+						$this->_run_rule($callback, $value, $params, $field);
+					}
 				}
 				$this->validated[$field->name] = $value;
 			}


### PR DESCRIPTION
There's a bug in Security class when input filter is on - when user's trying to input array of values it gets destroyed.
