### PR TITLE
Fixed session driver unserialize() function

### DIFF
--- a/fuel/core/classes/session/driver.php
+++ b/fuel/core/classes/session/driver.php
@@ -615,7 +615,7 @@ abstract class Session_Driver {
 	 */
 	protected function _unserialize($data)
 	{
-		$data = @unserialize(stripslashes($data));
+		$data = @unserialize($data);
 
 		if (is_array($data))
 		{


### PR DESCRIPTION
Removed stripslashes() from session driver. Doesn't add slashes in serialize function and isn't needed to unserialize when the str_replace() below compensates for slashes due to namespacing. The stripslashes() function breaks the unserializing of objects that use namespacing.
