### PR TITLE
Pagination-changes-2

### DIFF
--- a/fuel/app/classes/controller/welcome.php
+++ b/fuel/app/classes/controller/welcome.php
@@ -6,52 +6,7 @@ class Controller_Welcome extends Controller {
 
 	public function action_index()
 	{
-		//$this->render('welcome/index');
-		
-		$config = array(
-			'pagination_url' => \Uri::create('welcome/index'),
-			'total_items' => 17,
-			'per_page' => 5,
-			'uri_segment' => 3,
-		);
-	/*
-		$config = array(
-			'pagination_url' => \Uri::create('welcome/index/{p}?foo=bar'),
-			'total_items' => 17,
-			'per_page' => 5,
-			'uri_segment' => 3,
-			'method' => 'segment_tag',
-			
-			//hide the segment when page_nr == 1 
-			//'hide_1' => false, //default = true
-			
-			//set the tag that will be str_replaced with the page_nr in the pagination_url
-			//'replacement_tag' => ':page', // default ='{p}'
-		);
-		
-		*/
-		
-		
-	/*
-		$config = array(
-			'pagination_url' => \Uri::create('welcome/index?{p}&foo=bar'),
-			'total_items' => 17,
-			'per_page' => 5,
-			'method' => 'get_tag',
-		
-			// set the get variable name:
-			//'get_variable'  => 'pagina', //default = 'page'
-			
-			//hide the get variable when page_nr == 1 
-			//'hide_1' => false, //default = true
-			
-				//set the tag that will be str_replaced with the page_nr in the pagination_url
-			//'replacement_tag' => ':page', // default ='{p}'
-		);
-	*/
-		
-		Pagination::set_config($config);
-		echo Pagination::create_links();
+		$this->render('welcome/index');
 	}
 
 	public function action_404()

--- a/fuel/app/classes/controller/welcome.php
+++ b/fuel/app/classes/controller/welcome.php
@@ -6,56 +6,7 @@ class Controller_Welcome extends Controller {
 
 	public function action_index()
 	{
-		//$this->render('welcome/index');
-		
-		$config = array(
-			'pagination_url' => \Uri::create('welcome/index'),
-			'total_items' => 17,
-			'per_page' => 5,
-			'uri_segment' => 3,
-		);
-	
-	/*
-		$config = array(
-			'method' => 'segment_tag',
-			
-			//'pagination_url' => , // <-- not used
-			'uri_segment' => 3, 
-
-			'uri' => 'welcome/index/:page/', // <--- notice the colon (:)
-			'get_variables' => array('foo' => 'bar' ),
-
-			// 'variable_name' => 'page', // <--- notice NO colon (:)
-			
-			// hide the segment when page_nr == 1 
-			// 'hide_1' => false, //default = true
-						
-			'total_items' => 17,
-			'per_page' => 5,
-		);
-
-		*/
-		
-		/*
-		$config = array(
-			'method' => 'get_tag',
-			
-			//'pagination_url' => '', // <-- not used
-			//'uri_segment' => 3, // <-- not used 
-			
-			'uri' => 'welcome/index', 
-			'get_variables' => array('foo' => 'bar' ),	
-			
-			// 'variable_name' => 'page', 
-					
-			'total_items' => 17,
-			'per_page' => 5,
-		
-		);
-		*/
-		
-		Pagination::set_config($config);
-		echo Pagination::create_links();
+		$this->render('welcome/index');
 	}
 
 	public function action_404()

--- a/fuel/app/classes/controller/welcome.php
+++ b/fuel/app/classes/controller/welcome.php
@@ -6,7 +6,52 @@ class Controller_Welcome extends Controller {
 
 	public function action_index()
 	{
-		$this->render('welcome/index');
+		//$this->render('welcome/index');
+		
+		$config = array(
+			'pagination_url' => \Uri::create('welcome/index'),
+			'total_items' => 17,
+			'per_page' => 5,
+			'uri_segment' => 3,
+		);
+	/*
+		$config = array(
+			'pagination_url' => \Uri::create('welcome/index/{p}?foo=bar'),
+			'total_items' => 17,
+			'per_page' => 5,
+			'uri_segment' => 3,
+			'method' => 'segment_tag',
+			
+			//hide the segment when page_nr == 1 
+			//'hide_1' => false, //default = true
+			
+			//set the tag that will be str_replaced with the page_nr in the pagination_url
+			//'replacement_tag' => ':page', // default ='{p}'
+		);
+		
+		*/
+		
+		
+	/*
+		$config = array(
+			'pagination_url' => \Uri::create('welcome/index?{p}&foo=bar'),
+			'total_items' => 17,
+			'per_page' => 5,
+			'method' => 'get_tag',
+		
+			// set the get variable name:
+			//'get_variable'  => 'pagina', //default = 'page'
+			
+			//hide the get variable when page_nr == 1 
+			//'hide_1' => false, //default = true
+			
+				//set the tag that will be str_replaced with the page_nr in the pagination_url
+			//'replacement_tag' => ':page', // default ='{p}'
+		);
+	*/
+		
+		Pagination::set_config($config);
+		echo Pagination::create_links();
 	}
 
 	public function action_404()

--- a/fuel/app/classes/controller/welcome.php
+++ b/fuel/app/classes/controller/welcome.php
@@ -6,7 +6,56 @@ class Controller_Welcome extends Controller {
 
 	public function action_index()
 	{
-		$this->render('welcome/index');
+		//$this->render('welcome/index');
+		
+		$config = array(
+			'pagination_url' => \Uri::create('welcome/index'),
+			'total_items' => 17,
+			'per_page' => 5,
+			'uri_segment' => 3,
+		);
+	
+	/*
+		$config = array(
+			'method' => 'segment_tag',
+			
+			//'pagination_url' => , // <-- not used
+			'uri_segment' => 3, 
+
+			'uri' => 'welcome/index/:page/', // <--- notice the colon (:)
+			'get_variables' => array('foo' => 'bar' ),
+
+			// 'variable_name' => 'page', // <--- notice NO colon (:)
+			
+			// hide the segment when page_nr == 1 
+			// 'hide_1' => false, //default = true
+						
+			'total_items' => 17,
+			'per_page' => 5,
+		);
+
+		*/
+		
+		/*
+		$config = array(
+			'method' => 'get_tag',
+			
+			//'pagination_url' => '', // <-- not used
+			//'uri_segment' => 3, // <-- not used 
+			
+			'uri' => 'welcome/index', 
+			'get_variables' => array('foo' => 'bar' ),	
+			
+			// 'variable_name' => 'page', 
+					
+			'total_items' => 17,
+			'per_page' => 5,
+		
+		);
+		*/
+		
+		Pagination::set_config($config);
+		echo Pagination::create_links();
 	}
 
 	public function action_404()

--- a/fuel/core/classes/pagination.php
+++ b/fuel/core/classes/pagination.php
@@ -96,6 +96,9 @@ class Pagination {
 	 */
 	public static $variable_name = 'page';	
 
+	//remember initial var settings to reset them every time when set_config() is called (but not the first time - in _init)
+	protected static $reset;
+
 	/**
 	 * Init
 	 *
@@ -129,6 +132,16 @@ class Pagination {
 		{
 			static::${$key} = $value;
 		}
+
+		if ( ! (strtolower(static::$method) === static::CLASSIC) and ! empty(static::$pagination_url))
+		{
+			if (empty(static::$uri))
+			{
+				throw new \Fuel_Exception('Pagination::set_config() - "pagination_url" is only used with "method" => "classic", 
+					with "method" => "segment" or "get" you must use "uri" => "...". This exception was triggered  
+					because you did NOT set "uri", but you did set "pagination_url", and you set "method" => "'.static::$method.'"');
+			}
+		}  
 
 		static::initialize();
 	}

--- a/fuel/core/classes/pagination.php
+++ b/fuel/core/classes/pagination.php
@@ -59,7 +59,7 @@ class Pagination {
 
 	
 	/**
-	 * @var	bool	Hide pagination nr when method == SEGMENT_TAG / GET_TAG and page_nr == 1 (not supported in static::CLASSIC)
+	 * @var	bool	Hide pagination nr when method == SEGMENT / GET and page_nr == 1 (not supported in static::CLASSIC)
 	 */
 	protected static $hide_1 = true;
 	
@@ -69,12 +69,12 @@ class Pagination {
 	protected static $method = 'classic'; // static::CLASSIC
 	
 	const CLASSIC = 'classic';
-	const SEGMENT_TAG = 'segment_tag';
-	const GET_TAG = 'get_tag';
+	const SEGMENT = 'segment';
+	const GET = 'get';
 
 
 	/**
-	 * @var	string	To avoid confusing settings when method == segment_tag | get_tag, the uri will be set in $uri, not in $pagination_url
+	 * @var	string	To avoid confusing settings when method == segment | get, the uri will be set in $uri, not in $pagination_url
 	 */
 	public static $uri;	
 
@@ -91,8 +91,8 @@ class Pagination {
 	/**
 	 * @var	string	NOTICE: in $uri this must be preceded by colon: ':page' eg: 'monkeys/index/:page' 
 	 * this is because of how Uri::create works.
-	 * The segment placeholder when method == SEGMENT_TAG, 
-	 * eg: monkeys/index/:page, or if method == GET_TAG, the get var name
+	 * The segment placeholder when method == SEGMENT, 
+	 * eg: monkeys/index/:page, or if method == GET, the get var name
 	 */
 	public static $variable_name = 'page';	
 
@@ -277,7 +277,7 @@ class Pagination {
 		
 		switch (strtolower(static::$method)) 
 		{
-			case static::SEGMENT_TAG:
+			case static::SEGMENT:
 			
 				if($page_nr == 1 AND static::$hide_1 === true)
 				{
@@ -305,7 +305,7 @@ class Pagination {
 				
 				return \Uri::create($uri, $variables, $get_variables);
 				
-		  	case static::GET_TAG:
+		  	case static::GET:
 		  		
 		  		if($page_nr == 1 AND static::$hide_1 === true)
 				{
@@ -344,9 +344,9 @@ class Pagination {
 			default:
 				\Error::notice('The value of Pagination::$method is configured with an unknown and unsuported method: "'.static::$method.'". Falling back to "classic" method');
 			case static::CLASSIC:
-		  	case static::SEGMENT_TAG:
+		  	case static::SEGMENT:
 		  		return (int) \URI::segment(static::$uri_segment);
-		  	case static::GET_TAG:
+		  	case static::GET:
 		  		return (int) \Input::get(static::$variable_name, 1);
   		}
 	}


### PR DESCRIPTION
Added more functionality to Pagination class.

It has 3 operating modes: 
- classic (exactly as before, it is the default, no need to adjust anything in the way you use it)
- segment_tag 
- get_tag

See bellow for what the new operating modes do and how to activate them.

<pre>
// fully backwards compattible
// by default it behaves exactly as before,
// if you want to use the new functionality
// then set $config['method'] (see bellow)

//------------------------------------------------------------------------------------

// 'method' => 'classic' (default - behaves exactly as before)
//  no need to do anything different
$config = array(
    'pagination_url' => \Uri::create(),
    'total_items' => 17,
    'per_page' => 5,
    'uri_segment' => 3,
);
Pagination::set_config($config);
echo Pagination::create_links();

//------------------------------------------------------------------------------------

// 'method' => 'segment_tag'
//      usefull if you want to put the pagination nr somwhere other at the end of the pagination_url string
// behaviour:
//      instead of being appended to the end of pagination_url, 
//      the page_nr is str_eplaced where the '{p}' is
// possible uses:
//      'pagination_url' => \Uri::create('monkeys/index/{p}/foo')
//      'pagination_url' => \Uri::create('monkeys/index/{p}?foo=bar')


$config = array(
    'pagination_url' => \Uri::create('monkeys/index/{p}?foo=bar'),
    'total_items' => 17,
    'per_page' => 5,
    'uri_segment' => 3,
    'method' => 'segment_tag',
    
    //hide the segment when page_nr == 1 
    //'hide_1' => false, //default = true
    
    //set the tag that will be str_replaced with the page_nr in the pagination_url
    //'replacement_tag' => ':page', // default ='{p}'
);

//------------------------------------------------------------------------------------

//'method' => 'get_tag'
//      usefull if you want to put the pagination nr in a $_GET variable
// behaviour:
//      the page_nr is str_eplaced where the '{p}' is
//      for example if 
//          pagination_url = 'monkeys/index?{p}', 
//      then the url for page 2 will be:
//          'monkeys/index?page=2' 
// in case 'hide_1' == true (default), for page 1 the page number will be omited from the link url by create_links:
//      'monkeys/index' 
//      instead of 
//      'monkeys/index?page=1' 
// the '?' and the '&' symbols in the url will be inteligently adjusted when hiding the page nr for page 1
// possible uses:
//      'pagination_url' => \Uri::create('monkeys/index?{p}')
//      'pagination_url' => \Uri::create('monkeys/index?foo=bar&{p}&foose=snoose')
// you get the point

$config = array(
    'pagination_url' => \Uri::create('monkeys/index?{p}&foo=bar'),
    'total_items' => 17,
    'per_page' => 5,
    'method' => 'get_tag',

    // set the get variable name:
    //'get_variable'  => 'pagina', //default = 'page'
    
    //hide the get variable when page_nr == 1 
    //'hide_1' => false, //default = true
    
    //set the tag that will be str_replaced with the page_nr in the pagination_url
    //'replacement_tag' => ':page', // default ='{p}'
);
</pre>
