### PR TITLE
Migrations class structure

### DIFF
--- a/fuel/core/bootstrap.php
+++ b/fuel/core/bootstrap.php
@@ -126,7 +126,10 @@ Fuel\Core\Autoloader::add_classes(array(
 	'Fuel\\Core\\Input'						=> COREPATH.'classes/input.php',
 	'Fuel\\Core\\Lang'						=> COREPATH.'classes/lang.php',
 	'Fuel\\Core\\Log'						=> COREPATH.'classes/log.php',
+	
 	'Fuel\\Core\\Migrate'					=> COREPATH.'classes/migrate.php',
+	'Fuel\\Core\\Migrate_Exception'			=> COREPATH.'classes/migrate/exception.php',
+	
 	'Fuel\\Core\\Model'						=> COREPATH.'classes/model.php',
 	'Fuel\\Core\\Output'					=> COREPATH.'classes/output.php',
 	'Fuel\\Core\\Pagination'				=> COREPATH.'classes/pagination.php',

--- a/fuel/core/classes/migrate/exception.php
+++ b/fuel/core/classes/migrate/exception.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.0
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2010 - 2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+namespace Fuel\Core;
+
+
+class Migrate_Exception extends \Exception {}


### PR DESCRIPTION
Instead of migrations/001_migrate.php, migrations/002_someothercmigration.php, you now have:

migrations/main_001.php (class is Main_001 inside), migrations/main_002.php (class is Main_002 inside). This way you can have differnt app modules with their own migrations and run them all at the same time. You can also have the same name for a bunch of migrations and have the class names differnt (by having the numbers at the end).

Migrations currently are very limiting - you can't have two migrations with the same word as part of the name (as the class looked for is that word. When the Migrate class includes these php files, you get the whole can't redeclare class error.

I have proposed a restructure of the Migrate class before it's too late, for one main reason:
1. You can have multiple migrations from the same name.

Migrations are no longer named as follows:

001_migrate.php
002_someothernamebecausemigrateistaken.php

They are now:

migrate_001.php
migrate_002.php

And the migrations now look like so:
# migrations/migration_001.php

<?php

namespace Fuel\Migrations;

class Migration_001
{
    public function up()
    {

```
}
```

}
# migrations/migration_002.php

<?php

namespace Fuel\Migrations;

class Migration_002
{
    public function up()
    {

```
}
```

}

Down the track it would be great to have migrations in each module under app/modules/. Say you built a system on fuel that you sold, and there were addons, and these were just extra app modules. Having their own migrations would be awesome,
so you could update the module and have the migrations do the rest.
