### PR TITLE
Email bug fixes.

### DIFF
--- a/fuel/core/classes/email/driver.php
+++ b/fuel/core/classes/email/driver.php
@@ -615,7 +615,7 @@ abstract class Email_Driver {
 					}
 				}
 			}
-			$return .= "--".$boundary.$this->newline.$this->newline;
+                        $return .= "--".$boundary."--".$this->newline;
 		}
 		else if ($textCheck || $htmlCheck)
 		{
@@ -980,7 +980,7 @@ abstract class Email_Driver {
 
 		// wrap each line with the shebang, charset, and transfer encoding
 		// the preceding space on successive lines is required for header "folding"
-		$str = trim(preg_replace('/^(.*)$/m', ' =?'.$this->charset.'?Q?$1? = ', $str));
+		$str = trim(preg_replace('/^(.*)$/m', ' =?'.$this->charset.'?Q?$1?= ', $str));
 
 		return $str;
 	}

--- a/fuel/core/classes/email/driver.php
+++ b/fuel/core/classes/email/driver.php
@@ -615,7 +615,7 @@ abstract class Email_Driver {
 					}
 				}
 			}
-                        $return .= "--".$boundary."--".$this->newline;
+			$return .= "--".$boundary."--".$this->newline;
 		}
 		else if ($textCheck || $htmlCheck)
 		{

--- a/fuel/core/config/email.php
+++ b/fuel/core/config/email.php
@@ -21,7 +21,7 @@ return array(
 	 * Value is the location of the sendmail executable.
 	 * Defaults to '/usr/bin/sendmail'
 	 */
-	// 'mailpath' => '/usr/bin/sendmail',
+	// 'sendmail_path' => '/usr/bin/sendmail',
 
 	/* Sets the SMTP host to use when mailing through SMTP.
 	 * Value is the hostname of the SMTP server you are trying to connect to.


### PR DESCRIPTION
Fixed email title encoding problem. Fixed multipart email boundary ending problem. Fixes problem that gmail was not showing any message at all (only pure text emails was working). Fixed default config mailpath name to sendmail_path as in rest of email code.
