### PR TITLE
fixed lang class _parse_params function was not static 

### DIFF
--- a/fuel/core/classes/lang.php
+++ b/fuel/core/classes/lang.php
@@ -108,7 +108,7 @@ class Lang {
 		return false;
 	}
 
-	protected function _parse_params($string, $array = array())
+	protected static function _parse_params($string, $array = array())
 	{
 		$tr_arr = array();
 


### PR DESCRIPTION
issue 169

Non-static method Fuel\Core\Lang::_parse_params() should not be called statically in /.../fuel/fuel/core/classes/lang.php on line 93
