### PR TITLE
Add "Str" class to autoloader function in core bootstrap

### DIFF
--- a/fuel/core/bootstrap.php
+++ b/fuel/core/bootstrap.php
@@ -144,6 +144,8 @@ Fuel\Core\Autoloader::add_classes(array(
 	'Fuel\\Core\\Session_Memcached'			=> COREPATH.'classes/session/memcached.php',
 	'Fuel\\Core\\Session_Redis'				=> COREPATH.'classes/session/redis.php',
 
+     'Fuel\\Core\\Str'             => COREPATH.'classes/str.php',
+
 	'Fuel\\Core\\Uri'						=> COREPATH.'classes/uri.php',
 	'Fuel\\Core\\Upload'					=> COREPATH.'classes/upload.php',
 


### PR DESCRIPTION
Was working with Fuel and got an error about not being able to find the "Str" class; looked in Fuel's core bootstrap and realized it wasn't there. So I added it :)

By the way, I just wanted to say that I am _really_ impressed with Fuel; it truly does seem to take the best of the best frameworks and put them together in a really good way. Great job, and thanks!
