### PR TITLE
Bug Fix Crypt unable to load config properly

### DIFF
--- a/fuel/core/classes/crypt.php
+++ b/fuel/core/classes/crypt.php
@@ -60,7 +60,9 @@ class Crypt {
 		static::$have_mcrypt = function_exists('mcrypt_encrypt');
 
 		// load the config
-		$config = \Config::load('crypt', true);
+		\Config::load('crypt', true);
+
+		$config = \Config::get('crypt', array ());
 
 		// update the defaults with the configed values
 		foreach($config as $key => $value)


### PR DESCRIPTION
Problem with /core/classes/crypt.php assign $config from \Config::load instead of \Config::get
