### PR TITLE
Oil Generate model/migrate for date datatype

### DIFF
--- a/fuel/core/classes/crypt.php
+++ b/fuel/core/classes/crypt.php
@@ -60,7 +60,9 @@ class Crypt {
 		static::$have_mcrypt = function_exists('mcrypt_encrypt');
 
 		// load the config
-		$config = \Config::load('crypt', true);
+		\Config::load('crypt', true);
+
+		$config = \Config::get('crypt', array ());
 
 		// update the defaults with the configed values
 		foreach($config as $key => $value)

--- a/fuel/packages/oil/classes/generate.php
+++ b/fuel/packages/oil/classes/generate.php
@@ -244,7 +244,7 @@ VIEW;
 									$type = 'int';
 								}
 
-								if(!in_array($type, array('text', 'blob', 'datetime')))
+								if(!in_array($type, array('text', 'blob', 'datetime', 'date', 'timestamp', 'time')))
 								{
 									if(!isset($option[1]) || $option[1] == NULL)
 									{


### PR DESCRIPTION
Solve issue fuel/fuel#209

Create a notice on php cli and file error in migrations file.

Notice - Undefined index: date in DOCROOT/fuel/packages/oil/classes/generate.php on line 295
