### PR TITLE
Enable User to overwrite \Controller_Rest from automatically set header Content-Type

### DIFF
--- a/docs/general/controllers/rest.html
+++ b/docs/general/controllers/rest.html
@@ -88,6 +88,10 @@
 			<li><strong>serialize</strong> – Serialized data that can be unserialized in PHP</li>
 		</ul>
 
+		<p class="note">
+			Use <code>$this->set_format_header = false;</code> to prevent FuelPHP from sending a <code>\Output::set_header('Content-Type');</code>
+		</p>
+
 
 		<h3>Special controller methods</h3>
 

--- a/fuel/core/classes/controller/rest.php
+++ b/fuel/core/classes/controller/rest.php
@@ -6,6 +6,7 @@ abstract class Controller_Rest extends \Controller {
 
 	protected $rest_format = null; // Set this in a controller to use a default format
 	protected $methods = array(); // contains a list of method properties such as limit, log and level
+	protected $set_format_header = true; // Set this to true to automatically set the header's Content-Type
 
 	// List all supported methods, the first will be the default format
 	protected $_supported_formats = array(
@@ -90,8 +91,10 @@ abstract class Controller_Rest extends \Controller {
 		// If the format method exists, call and return the output in that format
 		if (method_exists('Controller_Rest', '_format_' . $this->request->format))
 		{
-			// Set the correct format header
-			\Output::set_header('Content-Type', $this->_supported_formats[$this->request->format]);
+			if ($this->set_format_header !== false) {
+				// Set the correct format header
+				\Output::set_header('Content-Type', $this->_supported_formats[$this->request->format]);
+			}
 
 			$this->output = $this->{'_format_' . $this->request->format}($data);
 		}


### PR DESCRIPTION
This work actually fine in normal environment but I came across a senario which what I would like to do is separate workflow into modules. 

Here's an example

``<?php

namespace Test;

class Controller_Sample extends \Controller_Rest {
    public function get_index() {
        $data = 'just some sample';

```
    $this->response($data, 200);
}
```

}``

So basically each module can have the request come in from a browser or another controller using `\Request::factory('test/sample/index.json')->execute();`

So if I call this from a browser or XHR request everything will work great, however if I would like to get the output from another Controller/Modules Controller a Content-Type header will always triggered when I set the output using `$this->response` method.

This change would allow me to do something as following

``<?php

namespace Test;

class Controller_Sample extends \Controller_Rest {

```
public function before() {
    if (\Request::main() != \Request::active()) {
        $this->set_format_header = false;
    }
}

public function get_index() {
    $data = 'just some sample';

    $this->response($data, 200);
}
```

}``
