### PR TITLE
Prevent from Redeclare Class Name PHP Error on Oil

### DIFF
--- a/docs/general/controllers/rest.html
+++ b/docs/general/controllers/rest.html
@@ -88,6 +88,10 @@
 			<li><strong>serialize</strong> – Serialized data that can be unserialized in PHP</li>
 		</ul>
 
+		<p class="note">
+			Use <code>$this->set_format_header = false;</code> to prevent FuelPHP from sending a <code>\Output::set_header('Content-Type');</code>
+		</p>
+
 
 		<h3>Special controller methods</h3>
 

--- a/fuel/core/classes/autoloader.php
+++ b/fuel/core/classes/autoloader.php
@@ -192,7 +192,7 @@ class Autoloader {
 
 			if ($file_path !== false)
 			{
-				require $file_path;
+				require_once $file_path;
 				if ( ! class_exists($class, false) && class_exists($class_name = 'Fuel\\Core\\'.$class, false))
 				{
 					static::alias_to_namespace($class_name);
@@ -219,7 +219,7 @@ class Autoloader {
 					{
 						// Fuel::$path_cache[$class] = $file_path;
 						// Fuel::$paths_changed = true;
-						require $file_path;
+						require_once $file_path;
 						static::_init_class($class);
 						return true;
 					}

--- a/fuel/core/classes/controller/rest.php
+++ b/fuel/core/classes/controller/rest.php
@@ -6,6 +6,7 @@ abstract class Controller_Rest extends \Controller {
 
 	protected $rest_format = null; // Set this in a controller to use a default format
 	protected $methods = array(); // contains a list of method properties such as limit, log and level
+	protected $set_format_header = true; // Set this to true to automatically set the header's Content-Type
 
 	// List all supported methods, the first will be the default format
 	protected $_supported_formats = array(
@@ -90,8 +91,10 @@ abstract class Controller_Rest extends \Controller {
 		// If the format method exists, call and return the output in that format
 		if (method_exists('Controller_Rest', '_format_' . $this->request->format))
 		{
-			// Set the correct format header
-			\Output::set_header('Content-Type', $this->_supported_formats[$this->request->format]);
+			if ($this->set_format_header !== false) {
+				// Set the correct format header
+				\Output::set_header('Content-Type', $this->_supported_formats[$this->request->format]);
+			}
 
 			$this->output = $this->{'_format_' . $this->request->format}($data);
 		}


### PR DESCRIPTION
even with the use of namespace, file path should always be unique so require_once would prevent possibility of PHP Compile Error Redeclare Class Name

This might be the cause of http://fuelphp.com/forums/topics/view/237 and http://fuelphp.com/forums/topics/view/229
