### PR TITLE
Solve issue Invalid Model file name & class name creation from oil generate

### DIFF
--- a/fuel/packages/oil/classes/generate.php
+++ b/fuel/packages/oil/classes/generate.php
@@ -90,8 +90,14 @@ CONTROLLER;
 		}
 
 		$plural = \Inflector::pluralize($singular);
+		
+		// Turn any model name with have underscore to camelcase format
+		$singular = \Inflector::camelize($singular);
+		
+		// filename should be in lowercase
+		$filename = strtolower($singular);
 
-		$filepath = APPPATH . 'classes/model/' . $singular .'.php';
+		$filepath = APPPATH . 'classes/model/' . $filename .'.php';
 
 		$class_name = ucfirst($singular);
 
@@ -100,7 +106,7 @@ CONTROLLER;
 
 class Model_{$class_name} extends ActiveRecord\Model { }
 
-/* End of file $singular.php */
+/* End of file $filename.php */
 MODEL;
 
 		if (self::write($filepath, $model))


### PR DESCRIPTION
Based on issue http://dev.fuelphp.com/issues/42

Not sure how to create a test case for this. But here a good example, I have a table 'users_roles' so basically I need to model for it.

`php oil g model usersRole user_id:int role_id:int` 
Will create Model_Usersrole at APPPATH/model/usersrole.php and migration script will create the table as usersroles.

`php oil g model users-role user_id:int role_id:int`
Will create an invalid Model_Users-role at APPPATH/model/users-role.php and the table name as users-roles

`php oil g model users_role user_id:int role_id:int`
Will create an invalid Model_Users_role at APPATH/model/users_role.php (it should be a /model/users/role.php) and the table name as users_roles.

So this changeset will enable anyone to use `php oil g model users_role user_id:int role_id:int` to generate Model_UsersRole at APPPATH/model/usersrole.php with table name as users_roles.
