### PR TITLE
Adding Transaction Functionality

### DIFF
--- a/fuel/core/classes/database.php
+++ b/fuel/core/classes/database.php
@@ -595,4 +595,44 @@ abstract class Database {
 	 */
 	abstract public function escape($value);
 
+	/**
+	 * Sets the Database instance to use transactions
+	 * Transactions are OFF by default
+	 *
+	 *     $db->transactional();
+	 *     $db->transactional(TRUE);
+	 *     $db->transactional(FALSE);
+	 *
+	 * @param   bool   use tranactions TRUE/FALSE
+	 * @return  void
+	 */
+	abstract public function transactional($use_trans = TRUE);
+
+	/**
+	 * Begins a transaction on instance
+	 *
+	 *     $db->start_transaction();
+	 *
+	 * @return  void
+	 */
+	abstract public function start_transaction();
+
+	/**
+	 * Commits all pending transactional queries
+	 *
+	 *     $db->commit_transaction();
+	 *
+	 * @return  void
+	 */
+	abstract public function commit_transaction();
+
+	/**
+	 * Rollsback all pending transactional queries
+	 *
+	 *     $db->rollback_transaction();
+	 *
+	 * @return  void
+	 */
+	abstract public function rollback_transaction();
+
 } // End Database_Connection

--- a/fuel/core/classes/database/mysql.php
+++ b/fuel/core/classes/database/mysql.php
@@ -183,7 +183,7 @@ class Database_MySQL extends \Database {
 				Profiler::delete($benchmark);
 			}
 			
-			if ($this->_trans_enabled) 
+			if ($type !== \Database::SELECT && $this->_trans_enabled) 
 			{
 				// If we are using transactions, throwing an exception would defeat the purpose
 				// We need to log the failures for transaction status

--- a/fuel/core/classes/database/mysql.php
+++ b/fuel/core/classes/database/mysql.php
@@ -401,5 +401,24 @@ class Database_MySQL extends \Database {
 			$this->_trans_enabled = $use_trans;
 		}
 	}
+	
+	public function start_transaction()
+	{
+		$this->transactional();
+		$this->query(0, 'SET AUTOCOMMIT=0', false);
+		$this->query(0, 'START TRANSACTION', false);
+	}
+
+	public function commit_transaction()
+	{
+		$this->query(0, 'COMMIT', false);
+		$this->query(0, 'SET AUTOCOMMIT=1', false);
+	}
+
+	public function rollback_transaction()
+	{
+		$this->query(0, 'ROLLBACK', false);
+		$this->query(0, 'SET AUTOCOMMIT=1', false);
+	}
 
 } // End Database_MySQL

--- a/fuel/core/classes/database/mysqli.php
+++ b/fuel/core/classes/database/mysqli.php
@@ -177,7 +177,7 @@ class Database_MySQLi extends \Database {
 				Profiler::delete($benchmark);
 			}
 			
-			if ($this->_trans_enabled) 
+			if ($type !== \Database::SELECT && $this->_trans_enabled) 
 			{
 				// If we are using transactions, throwing an exception would defeat the purpose
 				// We need to log the failures for transaction status

--- a/fuel/core/classes/database/mysqli.php
+++ b/fuel/core/classes/database/mysqli.php
@@ -395,5 +395,24 @@ class Database_MySQLi extends \Database {
 			$this->_trans_enabled = $use_trans;
 		}
 	}
+	
+	public function start_transaction()
+	{
+		$this->transactional();
+		$this->query(0, 'SET AUTOCOMMIT=0', false);
+		$this->query(0, 'START TRANSACTION', false);
+	}
+
+	public function commit_transaction()
+	{
+		$this->query(0, 'COMMIT', false);
+		$this->query(0, 'SET AUTOCOMMIT=1', false);
+	}
+
+	public function rollback_transaction()
+	{
+		$this->query(0, 'ROLLBACK', false);
+		$this->query(0, 'SET AUTOCOMMIT=1', false);
+	}
 
 } // End Database_MySQLi

--- a/fuel/core/classes/database/pdo.php
+++ b/fuel/core/classes/database/pdo.php
@@ -133,6 +133,7 @@ class Database_PDO extends \Database {
 				}
 				
 				$this->trans_errors[] = $e->getMessage().' with query: "'.$sql.'"';
+				return false;
 			}
 			else
 			{
@@ -210,6 +211,22 @@ class Database_PDO extends \Database {
 		if (is_bool($use_trans)) {
 			$this->_trans_enabled = $use_trans;
 		}
+	}
+	
+	public function start_transaction()
+	{
+		$this->transactional();
+		$this->_connection->beginTransaction();
+	}
+
+	public function commit_transaction()
+	{
+		$this->_connection->commit();
+	}
+
+	public function rollback_transaction()
+	{
+		$this->_connection->rollBack();
 	}
 
 } // End Database_PDO

--- a/fuel/core/classes/database/transaction.php
+++ b/fuel/core/classes/database/transaction.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Transactions for MySQL/MySQLi InnoDB
+ * Interact with Database Transactions
  *
  * @package    Fuel/Database
  * @category   Database
@@ -43,6 +43,7 @@ class Database_Transaction
 	public function __construct()
 	{
 		$this->_db = Database::instance();
+		$this->_db->connect();
 	}
 
 	/**
@@ -50,9 +51,7 @@ class Database_Transaction
 	*/
 	public function start()
 	{		
-		$this->_db->transactional();
-		$this->_db->query(0, 'SET AUTOCOMMIT=0', false);
-		$this->_db->query(0, 'START TRANSACTION', false);
+		$this->_db->start_transaction();
 	}
 
 	/**
@@ -88,8 +87,7 @@ class Database_Transaction
 	*/
 	public function commit()
 	{
-		$this->_db->query(0, 'COMMIT', false);
-		$this->_db->query(0, 'SET AUTOCOMMIT=1', false);
+		$this->_db->commit_transaction();
 	}
 	
 	/**
@@ -99,8 +97,7 @@ class Database_Transaction
 	*/
 	public function rollback()
 	{
-		$this->_db->query(0, 'ROLLBACK', false);
-		$this->_db->query(0, 'SET AUTOCOMMIT=1', false);
+		$this->_db->rollback_transaction();
 	}
 	
 	/**


### PR DESCRIPTION
This adds the same transactional functionality to \Fuel\Core\Database and driver as I added to the MySQLi driver.

http://fuelphp.com/forums/topics/view/386
http://fuelphp.com/forums/topics/view/407

Also patched MySQL & MySQLi behavior to only log transaction errors for non INSERT queries
