### PR TITLE
Allow required field errors to pop up even when input array and $_POST array are empy.

### DIFF
--- a/fuel/core/classes/dbutil.php
+++ b/fuel/core/classes/dbutil.php
@@ -122,6 +122,19 @@ class DBUtil {
 
 		return \implode(',', $sql_fields);
 	}
+
+	/**
+	 * Tuncates a table.
+	 *
+	 * @throws	Fuel\Database_Exception
+	 * @param	string	$table	the table name
+	 * @return	int		the number of affected rows
+	 */
+	public static function truncate_table($table)
+	{
+		return DB::query('TRUNCATE TABLE '.DB::quote_identifier($table), \Database::DELETE)->execute();
+	}
+
 }
 
 /* End of file dbutil.php */

--- a/fuel/core/classes/validation.php
+++ b/fuel/core/classes/validation.php
@@ -207,11 +207,6 @@ class Validation {
 	 */
 	public function run($input = null, $allow_partial = false)
 	{
-		if (empty($input) && empty($_POST))
-		{
-			return false;
-		}
-
 		$this->validated = array();
 		$this->errors = array();
 		$this->input = $input ?: array();
@@ -237,6 +232,11 @@ class Validation {
 			{
 				$this->errors[$field->name] = $v;
 			}
+		}
+		
+		if (empty($input) && empty($_POST))
+		{
+			return false;
 		}
 
 		return empty($this->errors);


### PR DESCRIPTION
Moved 'return false on empty input' further down to allow required field errors to pop up. Now it returns false on empty, without any errors.
