### PR TITLE
php_fatal_error.php javascript fix

### DIFF
--- a/fuel/core/views/errors/php_fatal_error.php
+++ b/fuel/core/views/errors/php_fatal_error.php
@@ -52,7 +52,7 @@
 				$debug_lines = \Debug::file_lines($trace['file'], $trace['line']);
 		?>
 			<li>
-				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>')"><?php echo Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
+				<a href="#" onclick="javascript:fuel_toggle('backtrace_<?php echo $id; ?>');return false;"><?php echo Fuel::clean_path($trace['file']).' @ line '.$trace['line']; ?></a>
 				<div id="backtrace_<?php echo $id; ?>" class="backtrace_block">
 <pre class="fuel_debug_source"><?php foreach ($debug_lines as $line_num => $line_content): ?>
 <span<?php echo ($line_num == $trace['line']) ? ' class="fuel_line fuel_current_line"' : ' class="fuel_line"'; ?>><span class="fuel_line_number"><?php echo str_pad($line_num, (strlen(count($debug_lines))), ' ', STR_PAD_LEFT); ?></span><span class="fuel_line_content"><?php echo $line_content . PHP_EOL; ?>
@@ -73,7 +73,7 @@
 			$debug_lines = \Debug::file_lines($orig_filepath, $error_line);
 		?>
 			<li>
-				<a href="#" onclick="javascript:fuel_toggle('non_fatal_<?php echo $id; ?>')"><?php echo $severity; ?>: <?php echo $message; ?> in <?php echo $filepath; ?> @ line <?php echo $error_line; ?></a>
+				<a href="#" onclick="javascript:fuel_toggle('non_fatal_<?php echo $id; ?>');return false;"><?php echo $severity; ?>: <?php echo $message; ?> in <?php echo $filepath; ?> @ line <?php echo $error_line; ?></a>
 				<div id="non_fatal_<?php echo $id; ?>" class="backtrace_block">
 <pre class="fuel_debug_source"><?php foreach ($debug_lines as $line_num => $line_content): ?>
 <span<?php echo ($line_num == $error_line) ? ' class="fuel_line fuel_current_line"' : ' class="fuel_line"'; ?>><span class="fuel_line_number"><?php echo str_pad($line_num, (strlen(count($debug_lines))), ' ', STR_PAD_LEFT); ?></span><span class="fuel_line_content"><?php echo $line_content . PHP_EOL; ?>


### PR DESCRIPTION
When expanding errors, it no longer returns to the top of the page. Simple, but can get annoying :p
