### PR TITLE
Controller_Rest return 404 if method is not found

### DIFF
--- a/fuel/core/classes/controller/rest.php
+++ b/fuel/core/classes/controller/rest.php
@@ -68,7 +68,16 @@ abstract class Controller_Rest extends \Controller {
 		// If they call user, go to $this->post_user();
 		$controller_method = strtolower(\Input::method()) . '_' . $resource;
 
-		call_user_func(array($this, $controller_method));
+		// If method is not available, set status code to 404
+		if (method_exists($this, $controller_method)) 
+		{
+			call_user_func(array($this, $controller_method));
+		}
+		else 
+		{
+			$this->response->status = 404;
+			return;
+		}
 	}
 
 	/*

--- a/fuel/core/classes/inflector.php
+++ b/fuel/core/classes/inflector.php
@@ -43,7 +43,7 @@ class Inflector {
 		'/(m)an$/'					=> '\1en',		// man, woman, spokesman
 		'/(c)hild$/'				=> '\1hildren',	// child
 		'/(buffal|tomat)o$/'		=> '\1\2oes',	// buffalo, tomato
-		'/(bu)s$/'					=> '\1\2ses',	// bus
+		'/(bu|campu)s$/'			=> '\1\2ses',	// bus
 		'/(alias|status|virus)/'	=> '\1es',		// alias
 		'/(octop)us$/'				=> '\1i',		// octopus
 		'/(ax|cri|test)is$/'		=> '\1es',		// axis, crisis
@@ -60,7 +60,7 @@ class Inflector {
 		'/(cris|ax|test)es$/'	=> '\1is',
 		'/(shoe)s$/'			=> '\1',
 		'/(o)es$/'				=> '\1',
-		'/(bus)es$/'			=> '\1',
+		'/(bus|campus)es$/'		=> '\1',
 		'/([m|l])ice$/'			=> '\1ouse',
 		'/(x|ch|ss|sh)es$/'		=> '\1',
 		'/(m)ovies$/'			=> '\1\2ovie',

--- a/fuel/core/tests/inflector.php
+++ b/fuel/core/tests/inflector.php
@@ -147,6 +147,14 @@ class Tests_Inflector extends TestCase {
 		$output = Inflector::pluralize('apple');
 		$expected = "apples";
 		$this->assertEquals($expected, $output);
+		
+		$output = Inflector::pluralize('cause');
+		$expected = 'causes';
+		$this->assertEquals($expected, $output);
+		
+		$output = Inflector::pluralize('campus');
+		$expected = 'campuses';
+		$this->assertEquals($expected, $output);
 	}
 
 	/**
@@ -158,6 +166,14 @@ class Tests_Inflector extends TestCase {
 	{
 		$output = Inflector::singularize('apples');
 		$expected = "apple";
+		$this->assertEquals($expected, $output);
+		
+		$output = Inflector::singularize('causes');
+		$expected = 'cause';
+		$this->assertEquals($expected, $output);
+		
+		$output = Inflector::singularize('campuses');
+		$expected = 'campus';
 		$this->assertEquals($expected, $output);
 	}
 

--- a/fuel/packages/oil/classes/command.php
+++ b/fuel/packages/oil/classes/command.php
@@ -121,7 +121,8 @@ class Command
 
 				case 't':
 				case 'test':
-
+					include_once('PHPUnit/Autoload.php');
+					
 					// Attempt to load PUPUnit.  If it fails, we are done.
 					if ( ! class_exists('PHPUnit_Framework_TestCase'))
 					{


### PR DESCRIPTION
Avoid throwing an error, if method is unavailable we should just output 404 instead of allowing PHP to throw an Error.
