### PR TITLE
(Image Lib) Some fixes and a few additions

### DIFF
--- a/fuel/core/classes/image.php
+++ b/fuel/core/classes/image.php
@@ -21,17 +21,24 @@ class Image {
 	protected static $_instance = null;
 
 	/**
+	 * Holds the config until an instance is initiated.
+	 *
+	 * @var  array   Config options to be passed when the instance is created.
+	 */
+	protected static $_config = array();
+
+	/**
 	 * Creates a new instance for static use of the class.
 	 *
 	 * @return  Image_Driver
 	 */
 	protected static function instance()
 	{
-		if (Image::$_instance == null)
+		if (static::$_instance == null)
 		{
-			Image::$_instance = Image::factory();
+			static::$_instance = static::factory(static::$_config);
 		}
-		return Image::$_instance;
+		return static::$_instance;
 	}
 
 	/**
@@ -42,6 +49,7 @@ class Image {
 	 */
 	public static function factory($config = array(), $filename = null)
 	{
+		!is_array($config) and $config = array();
 		$protocol = ucfirst( ! empty($config['driver']) ? $config['driver'] : 'gd');
 		$class = 'Image_'.$protocol;
 		if ($protocol == 'Driver' || ! class_exists($class))
@@ -59,12 +67,25 @@ class Image {
 	/**
 	 * Used to set configuration options.
 	 *
+	 * Sending the config options through the static reference initalizes the
+	 * instance. If you need to send a driver config through the static reference,
+	 * make sure its the first one sent! If errors arise, create a new instance using
+	 * factory().
+	 *
 	 * @param  array   $config   An array of configuration settings.
 	 * @return Image_Driver
 	 */
-	public static function config($config = array())
+	public static function config($index = array(), $value = null)
 	{
-		return Image::instance()->config($config);
+		if (static::$_instance === null)
+		{
+			if ($value !== null)
+				$index = array($index => $value);
+			if (is_array($index))
+				static::$_config = array_merge(static::$_config, $index);
+			static::instance();
+		}
+		return static::instance()->config($index, $value);;
 	}
 
 	/**
@@ -75,7 +96,7 @@ class Image {
 	 */
 	public static function load($filename)
 	{
-		return Image::instance()->load($filename);
+		return static::instance()->load($filename);
 	}
 
 	/**
@@ -91,7 +112,7 @@ class Image {
 	 */
 	public static function crop($x1, $y1, $x2, $y2)
 	{
-		return Image::instance()->crop($x1, $y1, $x2, $y2);
+		return static::instance()->crop($x1, $y1, $x2, $y2);
 	}
 
 	/**
@@ -105,7 +126,7 @@ class Image {
 	 */
 	public static function resize($width, $height, $keepar = true, $pad = false)
 	{
-		return Image::instance()->resize($width, $height, $keepar, $pad);
+		return static::instance()->resize($width, $height, $keepar, $pad);
 	}
 
 	/**
@@ -117,7 +138,7 @@ class Image {
 	 */
 	public static function crop_resize($width, $height)
 	{
-		return Image::instance()->crop_resize($width, $height);
+		return static::instance()->crop_resize($width, $height);
 	}
 
 	/**
@@ -128,7 +149,7 @@ class Image {
 	 */
 	public static function rotate($degrees)
 	{
-		return Image::instance()->rotate($degrees);
+		return static::instance()->rotate($degrees);
 	}
 
 	/**
@@ -141,7 +162,7 @@ class Image {
 	 */
 	public static function watermark($filename, $position, $padding = 5)
 	{
-		return Image::instance()->watermark($filename, $position, $padding);
+		return static::instance()->watermark($filename, $position, $padding);
 	}
 
 	/**
@@ -153,7 +174,7 @@ class Image {
 	 */
 	public static function border($size, $color = null)
 	{
-		return Image::instance()->border($size, $color);
+		return static::instance()->border($size, $color);
 	}
 
 	/**
@@ -164,7 +185,7 @@ class Image {
 	 */
 	public static function mask($maskimage)
 	{
-		return Image::instance()->mask($maskimage);
+		return static::instance()->mask($maskimage);
 	}
 
 	/**
@@ -177,7 +198,7 @@ class Image {
 	 */
 	public static function rounded($radius, $sides = null, $antialias = null)
 	{
-		return Image::instance()->rounded($radius, $sides, $antialias);
+		return static::instance()->rounded($radius, $sides, $antialias);
 	}
 
 	/**
@@ -185,11 +206,11 @@ class Image {
 	 *
 	 * @param  string  $filename     The location where to save the image.
 	 * @param  string  $permissions  Allows unix style permissions
-	 * @return string  The location of the file
+	 * @return Image_Driver
 	 */
 	public static function save($filename, $permissions = null)
 	{
-		return Image::instance()->save($filename, $permissions);
+		return static::instance()->save($filename, $permissions);
 	}
 
 	/**
@@ -198,21 +219,38 @@ class Image {
 	 * @param  string  $prepend      The text to add to the beginning of the filename.
 	 * @param  string  $append       The text to add to the end of the filename.
 	 * @param  string  $permissions  Allows unix style permissions
-	 * @return string  The location of the file
+	 * @return Image_Driver
 	 */
 	public static function save_pa($prepend, $append = null, $permissions = null)
 	{
-		return Image::instance()->save_pa($prepend, $append, $permissions);
+		return static::instance()->save_pa($prepend, $append, $permissions);
 	}
 
 	/**
 	 * Outputs the file directly to the user.
 	 *
 	 * @param  string  $filetype  The extension type to use. Ex: png, jpg, bmp, gif
+	 * @return Image_Driver
 	 */
 	public static function output($filetype = null)
 	{
-		Image::instance()->output($filetype);
+		return static::instance()->output($filetype);
+	}
+
+	/**
+	 * Returns sizes for the currently loaded image, or the image given in the $filename.
+	 *
+	 * @param	string	$filename	The location of the file to get sizes for.
+	 * @return	object	An object containing width and height variables.
+	 */
+	public static function sizes($filename = null)
+	{
+		return static::instance()->sizes();
+	}
+
+	public static function reload()
+	{
+		return static::instance()->reload();
 	}
 
 }

--- a/fuel/core/classes/image/driver.php
+++ b/fuel/core/classes/image/driver.php
@@ -247,7 +247,7 @@ abstract class Image_Driver {
 			// See which is the biggest ratio
 			$width_ratio  = $width / $sizes->width;
 			$height_ratio = $height / $sizes->height;
-			if ($width_ratio < $height_ratio)
+			if ($width_ratio > $height_ratio)
 			{
 				$width = floor($sizes->width * $height_ratio);
 			}
@@ -538,6 +538,11 @@ abstract class Image_Driver {
 			throw new \Fuel_Exception("Could not find directory \"$directory\"");
 		}
 
+		if ( ! $this->check_extension($filename, true))
+		{
+			$filename .= "." . $this->image_extension;
+		}
+
 		// Touch the file
 		if ( ! touch($filename))
 		{
@@ -548,11 +553,6 @@ abstract class Image_Driver {
 		if ($permissions != null and ! chmod($filename, $permissions))
 		{
 			throw new \Fuel_Exception("Could not set permissions on the file.");
-		}
-
-		if ( ! $this->check_extension($filename, true))
-		{
-			$filename .= "." . $this->image_extension;
 		}
 
 		$this->debug("", "Saving image as <code>$filename</code>");
@@ -633,7 +633,7 @@ abstract class Image_Driver {
 		$return = false;
 		foreach ($this->accepted_extension AS $ext)
 		{
-			if (substr($filename, strlen($ext) * -1) == $ext)
+			if (strtolower(substr($filename, strlen($ext) * -1)) == strtolower($ext))
 			{
 				$writevar and $this->image_extension = $ext;
 				$return = $ext;

--- a/fuel/core/classes/image/driver.php
+++ b/fuel/core/classes/image/driver.php
@@ -22,6 +22,7 @@ abstract class Image_Driver {
 	protected $image_directory = null;
 	protected $image_filename  = null;
 	protected $image_extension = null;
+	protected $new_extension   = null;
 	protected $config          = array();
 	protected $queued_actions  = array();
 	protected $accepted_extension;
@@ -81,6 +82,7 @@ abstract class Image_Driver {
 		{
 			throw new \Fuel_Exception("Could not load preset $name, you sure it exists?");
 		}
+		return $this;
 	}
 
 	/**
@@ -93,7 +95,6 @@ abstract class Image_Driver {
 	public function load($filename, $return_data = false)
 	{
 		// First check if the filename exists
-		$filename = realpath($filename);
 		$return = array(
 			'filename'    => $filename,
 			'return_data' => $return_data
@@ -594,6 +595,7 @@ abstract class Image_Driver {
 			{
 				header('Content-Type: image/' . $filetype);
 			}
+			$this->new_extension = $filetype;
 		}
 		else
 		{
@@ -635,6 +637,7 @@ abstract class Image_Driver {
 			{
 				$writevar and $this->image_extension = $ext;
 				$return = $ext;
+
 			}
 		}
 		return $return;
@@ -707,6 +710,16 @@ abstract class Image_Driver {
 		{
 			$this->queued_actions = array();
 		}
+	}
+
+	/**
+	 * Reloads the image.
+	 */
+	public function reload()
+	{
+		$this->debug("Reloading was called!");
+		$this->load($this->image_fullpath);
+		return $this;
 	}
 
 	/**

--- a/fuel/core/classes/image/imagemagick.php
+++ b/fuel/core/classes/image/imagemagick.php
@@ -19,7 +19,7 @@ namespace Fuel\Core;
 class Image_Imagemagick extends Image_Driver {
 
 	private $image_temp = null;
-	protected $accepted_extension = array('png', 'gif', 'jpg', 'jpeg');
+	protected $accepted_extension = array('png', 'gif', 'jpg', 'jpeg', 'psd');
 	private $size_cache = null;
 
 	public function load($filename)
@@ -49,7 +49,7 @@ class Image_Imagemagick extends Image_Driver {
 		{
 			throw new \Fuel_Exception("Could not write in the temp directory.");
 		}
-		$this->exec('convert', '"'.$image_fullpath.'" "'.$this->image_temp.'"');
+		$this->exec('convert', '"'.$image_fullpath.'"[0] "'.$this->image_temp.'"');
 		return $this;
 	}
 
@@ -158,7 +158,7 @@ class Image_Imagemagick extends Image_Driver {
 				$filename = $this->image_temp;
 			}
 
-			$output = $this->exec('identify', '-format "%[fx:w] %[fx:h]" "'.$filename.'"');
+			$output = $this->exec('identify', '-format "%[fx:w] %[fx:h]" "'.$filename.'"[0]');
 			list($width, $height) = explode(" ", $output[0]);
 			$return = (object) array(
 				'width' => $width,
@@ -268,7 +268,8 @@ class Image_Imagemagick extends Image_Driver {
 			}
 			else
 			{
-				throw new \Fuel_Exception("imagemagick failed to edit the image. Returned with $code.");
+				$message = implode('\n', $output);
+				throw new \Fuel_Exception("imagemagick failed to edit the image. Returned with $code.<br /><br />Command:\n <code>$command</code>");
 			}
 		}
 		return $output;

--- a/fuel/core/config/image.php
+++ b/fuel/core/config/image.php
@@ -36,12 +36,12 @@ return array(
 	/**
 	 * The install location of the imagemagick executables.
 	 */
-	'imagemagick_dir' => 'C:/wamp/imagemagick/',
+	'imagemagick_dir' => '/usr/bin/',
 
 	/**
 	 * Temporary directory to store image files in that are being edited.
 	 */
-	'temp_dir' => 'C:/wamp/tmp/',
+	'temp_dir' => '/tmp/',
 
 	/**
 	 * The string of text to append to the image.
@@ -51,13 +51,20 @@ return array(
 	/**
 	 * Sets if the queue should be cleared after a save(), save_pa(), or output().
 	 */
-	'clear_queue' => false,
+	'clear_queue' => true,
+
+	/**
+	 * Sets if the image should be reloaded after previous modifications
+	 *
+	 * true makes changes persist, false reloads after each save (includes save_pa).
+	 */
+	'persistence' => false,
 
 	/**
 	 * Used to debug the class, defaults to false.
 	 */
 	'debug' => false,
-	
+
 	/**
 	 * These presets allow you to call controlled manipulations.
 	 */
@@ -77,8 +84,7 @@ return array(
 			'actions' => array(
 				array('crop_resize', 200, 200),
 				array('border', 20, "#f00"),
-				array('rounded', 10),
-				array('output', 'png')
+				array('rounded', 10)
 			)
 		)
 	)


### PR DESCRIPTION
Bug fixes:
- Transparency in gifs is lost when outputting in GD
- Transparency when outputting jpegs with no bgcolor loses some of the alpha channel in GD
- Outputting non-PNG images as the format they were previously in (Such as a outputting a gif as a gif) would result in a PNG image in ImageMagick driver.
- reload() was not chainable.
- Use of config() in the static reference didn't allow usage with index value pairs.

Few other fixes and such added.

(Update)

More Bug Fixes:
- Fixed bug with saving a blank file without extension.
- Fixed bug with not accepting uppercase extensions.
- Fixed bug with resize() when width and height are supplied (Cropped instead of resized).

Also added inital support for PSDs (Still needs testing) and possibly other formats in imagemagick.
