### PR TITLE
Create a config key 'default_charset' for DBUtil usage.

### DIFF
--- a/fuel/app/config/db.php
+++ b/fuel/app/config/db.php
@@ -13,6 +13,8 @@
 return array(
 	'active' => Config::get('environment'),
 
+	'default_charset' => null,
+
 	Fuel::DEVELOPMENT => array(
 		'type'			=> 'mysql',
 		'connection'	=> array(


### PR DESCRIPTION
This key can be set to a default charset so people can ommit it from DBUtil usage.
