### PR TITLE
Provide the ability to specify a directory of shared packages to allow shared and project specific packages

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -15,6 +15,11 @@ call_user_func(function() {
 	$package_path	= '../fuel/packages/';
 	$core_path		= '../fuel/core/';
 
+	/**
+	 * Set this if you have an additional directory of shared packages
+	 */
+	// $shared_package_path	= '/shared/fuel/packages/';
+
 
 	/**
 	 * Website docroot
@@ -24,9 +29,11 @@ call_user_func(function() {
 	( ! is_dir($app_path) and is_dir(DOCROOT.$app_path)) and $app_path = DOCROOT.$app_path;
 	( ! is_dir($core_path) and is_dir(DOCROOT.$core_path)) and $core_path = DOCROOT.$core_path;
 	( ! is_dir($package_path) and is_dir(DOCROOT.$package_path)) and $package_path = DOCROOT.$package_path;
+	( isset($shared_package_path) and ! is_dir($shared_package_path) and is_dir(DOCROOT.$shared_package_path)) and $shared_package_path = DOCROOT.$shared_package_path;
 
 	define('APPPATH', realpath($app_path).DIRECTORY_SEPARATOR);
 	define('PKGPATH', realpath($package_path).DIRECTORY_SEPARATOR);
+	isset($shared_package_path) and define('SHAREDPKGPATH', realpath($shared_package_path).DIRECTORY_SEPARATOR);
 	define('COREPATH', realpath($core_path).DIRECTORY_SEPARATOR);
 
 });


### PR DESCRIPTION
We saw this as a necessity for many organisations who wish to use Fuel as a development platform for many sites. They would ideally like to have a set of tried and tested shared packages which any developer can use in any project. They would also like to have packages local to a particular project. Some local packages would, at the end of the development on a particular project, be put into the shared directory.

This is twinned with a commit to phil-lavin/core which I will also do a pull request for.
