### PR TITLE
Adding the full path to php in oil executable

### DIFF
--- a/oil
+++ b/oil
@@ -1,3 +1,4 @@
+#!/usr/bin/php
 <?php
 /**
  * Set error reporting and display errors settings.  You will want to change these when in production.


### PR DESCRIPTION
When you need to put a oil refine to a cronjob you need to put the full path of oil executable. But, the script doesnt "know" how to execute it. I added the "#!/usr/bin/php", in the file to get this fixed.
