### PR TITLE
Suppress “ini_set() has been disabled for security reasons”

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
  * Set error reporting and display errors settings.  You will want to change these when in production.
  */
 error_reporting(-1);
-ini_set('display_errors', 1);
+@ini_set('display_errors', 1);
 
 /**
  * Website document root


### PR DESCRIPTION
A few servers that I use have `ini_set()` disabled, so this is something that I have had to change a few times. I don’t think it affects anybody who has it enabled, nor do they need to know it’d disabled (because they probably already do).
