### PR TITLE
Remove comment before 'orm'

### DIFF
--- a/fuel/app/config/config.php
+++ b/fuel/app/config/config.php
@@ -185,7 +185,7 @@ return array(
 		 * );
 		 */
 		'packages'  => array(
-			//'orm',
+			'orm',
 		),
 
 		/**


### PR DESCRIPTION
Since oil generate a code which need the orm package, and since we will generally use this package on FuelPHP, I suggest to remove the comment before 'orm'...
