### PR TITLE
Updated oil to remove carriage return.

### DIFF
--- a/oil
+++ b/oil
@@ -37,6 +37,4 @@ Package::load('oil');
 // Fire up the command line interfact
 Oil\Command::init($_SERVER['argv']);
 
-echo PHP_EOL;
-
 /* End of file oil */


### PR DESCRIPTION
Was printing a carriage return which causes schedulers (eg. cron) to output a carriage return on every run even if not wanted.
