### PR TITLE
removed the compulsory output of a new line in oil

### DIFF
--- a/oil
+++ b/oil
@@ -45,6 +45,4 @@ Package::load('oil');
 // Fire up the command line interfact
 Oil\Command::init($_SERVER['argv']);
 
-echo PHP_EOL;
-
 /* End of file oil */


### PR DESCRIPTION
It should be possible to have a task return no output, rather than forcing you to have a new line output
