### PR TITLE
Changelog update for DB::query->bind()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * __DB__: `where()` do now support closures to specify the where clause.
 * __DB__: Update now supports `limit()` and `order_by()`.
 * __DB__: now tries to reconnect when a disconnected DB connection is detected.
+* __DB__: `bind()` automatically prefixes parameter keys with `:`
 * __DButil__: `create_database()` now supports 'IF NOT EXIST'.
 * __DButil__: Better support for the CONSTRAINT keyword.
 * __DButil__: new `add_foreign_key()` and `drop_foreign_key()` methods.


### PR DESCRIPTION
As of https://github.com/fuel/core/commit/16f8b10a370b031a878cd9fdd5b94b1671153d4b `bind()` automatically prefixes parameter keys with a `:` (due to using `Str::tr()` over `strtr()`)
