### PR TITLE
Removed replacing exec time and mem usage from response on every request...

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -71,15 +71,4 @@ catch (HttpNotFoundException $e)
 	}
 }
 
-// This will add the execution time and memory usage to the output.
-// Comment this out if you don't use it.
-$bm = Profiler::app_total();
-$response->body(
-	str_replace(
-		array('{exec_time}', '{mem_usage}'),
-		array(round($bm[0], 4), round($bm[1] / pow(1024, 2), 3)),
-		$response->body()
-	)
-);
-
 $response->send(true);


### PR DESCRIPTION
Wouldn't it be best to force developrs who want to display this to call the profiler manaully in their controller and pass to their view? I think this is very early 1.0 code?

I know it says comment it out, but it seems like most people (myself guilty as well) probably wouldn't.

Seems unneeded overhead. Just a thought. :metal:
