### PR TITLE
Adds branch aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,10 @@
         "vendor-dir": "fuel/vendor"
     },
     "extra": {
+        "branch-alias": {
+            "dev-1.8/develop": "1.7.x-dev",
+            "dev-1.7/master": "1.7.2"
+        },
         "installer-paths": {
             "fuel/{$name}": ["fuel/core"],
             "{$name}": ["fuel/docs"]


### PR DESCRIPTION
This way version numbers can be used instead of branch names. Based on [this](https://getcomposer.org/doc/articles/aliases.md#branch-alias).
