### PR TITLE
Change composer.json to use vcs repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": ">=5.3.3",
         "composer/installers": "~1.0",
-        "fuel/docs": "dev-1.8/develop",
         "fuel/core": "dev-1.8/develop",
         "fuel/auth": "dev-1.8/develop",
         "fuel/email": "dev-1.8/develop",
@@ -26,6 +25,9 @@
         "fuelphp/upload": "2.0.2",
         "monolog/monolog": "1.5.*",
         "michelf/php-markdown": "1.4.0"
+    },
+    "require-dev": {
+        "fuel/docs": "dev-1.8/develop"
     },
     "suggest": {
         "dwoo/dwoo" : "Allow Dwoo templating with the Parser package",

--- a/composer.json
+++ b/composer.json
@@ -5,136 +5,24 @@
     "keywords": ["application", "website", "development", "framework", "PHP"],
     "license": "MIT",
     "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/auth",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/auth/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/auth.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/email",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/email/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/email.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/oil",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/oil/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/oil.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/orm",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/orm/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/orm.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/parser",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/parser/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/parser.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/core",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/core/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/core.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "fuel/docs",
-                "type": "fuel-package",
-                "version": "1.7.2",
-                "dist": {
-                    "url": "https://github.com/fuel/docs/archive/1.7/master.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/fuel/docs.git",
-                    "type": "git",
-                    "reference": "1.8/develop"
-                }
-            }
-        }
+        { "type": "vcs", "url": "https://github.com/fuel/docs" },
+        { "type": "vcs", "url": "https://github.com/fuel/core" },
+        { "type": "vcs", "url": "https://github.com/fuel/auth" },
+        { "type": "vcs", "url": "https://github.com/fuel/email" },
+        { "type": "vcs", "url": "https://github.com/fuel/oil" },
+        { "type": "vcs", "url": "https://github.com/fuel/orm" },
+        { "type": "vcs", "url": "https://github.com/fuel/parser" }
     ],
     "require": {
         "php": ">=5.3.3",
         "composer/installers": "~1.0",
-        "fuel/docs": "1.7.2",
-        "fuel/core": "1.7.2",
-        "fuel/auth": "1.7.2",
-        "fuel/email": "1.7.2",
-        "fuel/oil": "1.7.2",
-        "fuel/orm": "1.7.2",
-        "fuel/parser": "1.7.2",
+        "fuel/docs": "dev-1.8/develop",
+        "fuel/core": "dev-1.8/develop",
+        "fuel/auth": "dev-1.8/develop",
+        "fuel/email": "dev-1.8/develop",
+        "fuel/oil": "dev-1.8/develop",
+        "fuel/orm": "dev-1.8/develop",
+        "fuel/parser": "dev-1.8/develop",
         "fuelphp/upload": "2.0.2",
         "monolog/monolog": "1.5.*",
         "michelf/php-markdown": "1.4.0"


### PR DESCRIPTION
Now we use "repoistories - type -package". But it has a few limitations.
See Note on https://getcomposer.org/doc/05-repositories.md#package-2

If you merge this PR, we will have no limitations.

But now we use `--prefer-dist` and `--prefer-source` with special meanings, "source" means 1.8/develop (git) and "dist" means 1.7/master (zip file). If you merge this PR, you can't use the trick. And after merging, you have to change "version" properly before releases.
